### PR TITLE
Initial version of drag-n-drop for the left tree view.

### DIFF
--- a/Snoop/ProperTreeView.cs
+++ b/Snoop/ProperTreeView.cs
@@ -176,6 +176,15 @@ namespace Snoop
         private Point offset;
     }
 
+    /// <summary>
+    /// I really like the concept of the WPF Behavior class, but I do not want to include another
+    /// assembly in Snoop since I want to keep it as light and portable as possible (and backwards-
+    /// compatible with version 3.5). I really wanted to encapsulate the drag-n-drop functionality
+    /// in another class, and thought that this was the optimal approach. Any feedback would be greatly
+    /// appreciated.
+    /// </summary>
+    /// <typeparam name="T">The type of the item being dragged.</typeparam>
+    /// <typeparam name="ContainerType">The type of the container of the items being dragged (such as Grid, or in our case below, TreeView).</typeparam>
     public abstract class DragDropBehavior<T, ContainerType>
         where T : Control
         where ContainerType : Control

--- a/Snoop/ProperTreeView.cs
+++ b/Snoop/ProperTreeView.cs
@@ -197,7 +197,6 @@ namespace Snoop
             item.MouseMove += Item_MouseMove;
             item.DragOver += Item_DragOver;
             item.DragLeave += Item_DragLeave;
-
         }
 
         protected T _item;

--- a/Snoop/ProperTreeView.cs
+++ b/Snoop/ProperTreeView.cs
@@ -224,11 +224,11 @@ namespace Snoop
 
                 var item = VisualTreeHelper2.GetAncestor<ContainerType>(_item);
                 Point p = e.GetPosition(item);
-                AddAddornerToTree(p);
+                AddAddornerToContainer(p);
                 DragDrop.DoDragDrop(ellipse,
                                      data,
                                      DragDropEffects.All);
-                RemoveAddornerFromTree();
+                RemoveAddornerFromContainer();
             }
 
             e.Handled = true;
@@ -253,9 +253,9 @@ namespace Snoop
             e.Handled = true;
         }
 
-        private void AddAddornerToTree(Point p)
+        private void AddAddornerToContainer(Point p)
         {
-            var treeView = VisualTreeHelper2.GetAncestor<TreeView>(_item);
+            var treeView = VisualTreeHelper2.GetAncestor<ContainerType>(_item);
             if (treeView != null)
             {
                 var adornerLayer = System.Windows.Documents.AdornerLayer.GetAdornerLayer(treeView);
@@ -265,9 +265,9 @@ namespace Snoop
             }
         }
 
-        private void RemoveAddornerFromTree()
+        private void RemoveAddornerFromContainer()
         {
-            var treeView = VisualTreeHelper2.GetAncestor<TreeView>(_item);
+            var treeView = VisualTreeHelper2.GetAncestor<ContainerType>(_item);
             if (treeView != null)
             {
                 var adornerLayer = System.Windows.Documents.AdornerLayer.GetAdornerLayer(treeView);

--- a/Snoop/ProperTreeView.cs
+++ b/Snoop/ProperTreeView.cs
@@ -137,11 +137,188 @@ namespace Snoop
 		private WeakReference _rootItem = new WeakReference(null);
 	}
 
+    public class TreeItemDragDropData
+    {
+        public Visual DraggedVisual { get; set; }
+        public ResourceContainerItem DataItem { get; set; }
+    }
+
+    public class DragAdorner : System.Windows.Documents.Adorner
+    {
+        public DragAdorner(UIElement adornedElement, Point offset)
+            : base(adornedElement)
+        {
+
+            this.offset = offset;
+            vbrush = new VisualBrush(AdornedElement);
+            vbrush.Opacity = .7;
+            this.IsHitTestVisible = false;
+        }
+
+        public void UpdatePosition(Point location)
+        {
+            this.location = location;
+            this.InvalidateVisual();
+        }
+
+        protected override void OnRender(DrawingContext dc)
+        {
+            var p = location;
+
+            p.Offset(-offset.X, -offset.Y);
+            //var p = offset;
+            System.Diagnostics.Debug.WriteLine(string.Format("onrender p = {0}", p));
+            dc.DrawRectangle(vbrush, null, new Rect(p, this.RenderSize));
+        }
+
+        private Brush vbrush;
+        private Point location;
+        private Point offset;
+    }
+
+    public abstract class DragDropBehavior<T, ContainerType>
+        where T : Control
+        where ContainerType : Control
+    {
+        public void Attach(T item)
+        {
+            _item = item;
+            item.AllowDrop = true;
+            item.Drop += ProperTreeViewItem_Drop;
+            item.MouseMove += ProperTreeViewItem_MouseMove;
+            item.DragOver += ProperTreeViewItem_DragOver;
+            item.DragLeave += ProperTreeViewItem_DragLeave;
+
+        }
+
+        protected T _item;
+
+        protected abstract object PackageDataForDrag();
+
+        protected abstract void OnDrop(DragEventArgs e);
+
+        private void ProperTreeViewItem_Drop(object sender, DragEventArgs e)
+        {
+            _item.Background = Brushes.Transparent;
+            OnDrop(e);
+            e.Handled = true;
+        }
+
+        private static DragAdorner _dragAdorner;
+        private void ProperTreeViewItem_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            var ellipse = sender as FrameworkElement;
+
+            if (ellipse != null && e.LeftButton == System.Windows.Input.MouseButtonState.Pressed)
+            {
+                object data = PackageDataForDrag();
+
+                var item = VisualTreeHelper2.GetAncestor<ContainerType>(_item);
+                Point p = e.GetPosition(item);
+                AddAddornerToTree(p);
+                DragDrop.DoDragDrop(ellipse,
+                                     data,
+                                     DragDropEffects.All);
+                RemoveAddornerFromTree();
+            }
+
+            e.Handled = true;
+        }
+
+
+        private void ProperTreeViewItem_DragLeave(object sender, DragEventArgs e)
+        {
+            _item.Background = Brushes.Transparent;
+            e.Handled = true;
+        }
+
+        private void ProperTreeViewItem_DragOver(object sender, DragEventArgs e)
+        {
+            _item.Background = Brushes.Yellow;
+            var containerElement = VisualTreeHelper2.GetAncestor<ContainerType>(_item);
+            if (_dragAdorner != null)
+            {
+                _dragAdorner.UpdatePosition(e.GetPosition(containerElement));
+            }
+            var point = System.Windows.Input.Mouse.GetPosition(containerElement);
+            e.Handled = true;
+        }
+
+        private void AddAddornerToTree(Point p)
+        {
+            var treeView = VisualTreeHelper2.GetAncestor<TreeView>(_item);
+            if (treeView != null)
+            {
+                var adornerLayer = System.Windows.Documents.AdornerLayer.GetAdornerLayer(treeView);
+                _dragAdorner = new DragAdorner(_item, p);
+                adornerLayer.Add(_dragAdorner);
+
+            }
+        }
+
+        private void RemoveAddornerFromTree()
+        {
+            var treeView = VisualTreeHelper2.GetAncestor<TreeView>(_item);
+            if (treeView != null)
+            {
+                var adornerLayer = System.Windows.Documents.AdornerLayer.GetAdornerLayer(treeView);
+                adornerLayer.Remove(_dragAdorner);
+            }
+        }
+    }
+
+    public class SnoopDragDropBehavior : DragDropBehavior<ProperTreeViewItem, TreeView>
+    {
+        protected override object PackageDataForDrag()
+        {
+            TreeItemDragDropData data = new TreeItemDragDropData();
+            data.DraggedVisual = ((ResourceContainerItem)_item.DataContext).MainVisual;
+            data.DataItem = ((ResourceContainerItem)_item.DataContext);
+            return data;
+        }
+
+        protected override void OnDrop(DragEventArgs e)
+        {
+            object[] data = (object[])e.Data.GetData(typeof(object[]));
+            TreeItemDragDropData treeItemData = null;
+            if ((treeItemData = e.Data.GetData(typeof(TreeItemDragDropData)) as TreeItemDragDropData) != null)
+            {
+                TreeItemDrop(treeItemData);
+            }
+        }
+
+        private void TreeItemDrop(TreeItemDragDropData treeItemData)
+        {
+            //ProperTreeViewItem droppedTreeItem = (ProperTreeViewItem)sender;
+            var draggedVisual = (FrameworkElement)treeItemData.DraggedVisual;
+            var droppedVisual = (FrameworkElement)((VisualTreeItem)_item.DataContext).MainVisual;
+            var panel = draggedVisual.Parent as Panel;
+            if (panel == null)
+                return;
+            var targetPanel = droppedVisual as Panel;
+            if (targetPanel == null)
+                return;
+            if (targetPanel == draggedVisual)
+                return;
+            panel.Children.Remove(draggedVisual);
+            targetPanel.Children.Add(draggedVisual);
+
+            VisualTreeItem highestParent = treeItemData.DataItem;
+            while (highestParent.Parent != null)
+                highestParent = highestParent.Parent;
+
+            highestParent.Reload();
+        }
+
+    }
+
 	public class ProperTreeViewItem : TreeViewItem
 	{
+        SnoopDragDropBehavior _dragDropBehavior = new SnoopDragDropBehavior();
 		public ProperTreeViewItem(WeakReference treeView)
 		{
 			_treeView = treeView;
+            _dragDropBehavior.Attach(this);
 		}
 
 		public double Indent


### PR DESCRIPTION
It would be cool (and at times useful) to be able to drag visuals from one panel to another. For example, if I want to see how something looks like when moved to another grid, this feature allows the developer to do so.
