### PR TITLE
It crashes on sort.

### DIFF
--- a/Snoop/PropertyGrid2.xaml.cs
+++ b/Snoop/PropertyGrid2.xaml.cs
@@ -238,8 +238,14 @@ namespace Snoop
 			GridViewColumnHeader headerClicked = (GridViewColumnHeader)args.OriginalSource;
 
 			direction = GetNewSortDirection(headerClicked);
+            if (headerClicked.Column == null)
+                return;
 
-			switch (((TextBlock)headerClicked.Column.Header).Text)
+            var columnHeader = headerClicked.Column.Header as TextBlock;
+            if (columnHeader == null)
+                return;
+
+            switch (columnHeader.Text)
 			{
 				case "Name":
 					this.Sort(PropertyGrid2.CompareNames, direction);


### PR DESCRIPTION
If you click the header on the very left without any text, the Snooped application will crash.