### PR TITLE
Implement tree dump to XML

### DIFF
--- a/Snoop/Icons.xaml
+++ b/Snoop/Icons.xaml
@@ -236,6 +236,22 @@ All other rights reserved.
 		</DrawingImage.Drawing>
 	</DrawingImage>
 
+	<!-- exportDrawingImage -->
+	<DrawingImage x:Key="exportDrawingImage">
+		<DrawingImage.Drawing>
+			<DrawingGroup>
+				<DrawingGroup.Children>
+					<GeometryDrawing Brush="#FF000000" Geometry="M 20.5833 20.5833L 55.4167 20.5833L 55.4167 55.4167L 45.9167 55.4167L 45.9167 44.3333L 30.0833 44.3333L 30.0833 55.4167L 20.5833 55.4167L 20.5833 20.5833 Z M 33.25 55.4167L 33.25 50.6667L 39.5833 50.6667L 39.5833 55.4167L 33.25 55.4167 Z M 26.9167 23.75L 26.9167 33.25L 49.0833 33.25L 49.0833 23.75L 26.9167 23.75 Z">
+						<GeometryDrawing.Pen>
+							<Pen Thickness="0.2"  MiterLimit="2"/>
+						</GeometryDrawing.Pen>
+					</GeometryDrawing>
+
+				</DrawingGroup.Children>
+			</DrawingGroup>
+		</DrawingImage.Drawing>
+	</DrawingImage>
+
 	<!-- cameraIcon -->
 	<DrawingImage x:Key="cameraDrawingImage">
 		<DrawingImage.Drawing>

--- a/Snoop/Properties/Settings.Designer.cs
+++ b/Snoop/Properties/Settings.Designer.cs
@@ -128,29 +128,57 @@ namespace Snoop.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("\r\n        <?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n        <ArrayOfPropertyFilter" +
-            "Set xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n        xmlns:xsd=\"ht" +
-            "tp://www.w3.org/2001/XMLSchema\">\r\n        <PropertyFilterSet>\r\n        <DisplayN" +
-            "ame>Layout</DisplayName>\r\n        <IsDefault>false</IsDefault>\r\n        <IsEditC" +
-            "ommand>false</IsEditCommand>\r\n        <Properties>\r\n        <string>width</strin" +
-            "g>\r\n        <string>height</string>\r\n        <string>actualwidth</string>\r\n     " +
-            "   <string>actualheight</string>\r\n        <string>margin</string>\r\n        <stri" +
-            "ng>padding</string>\r\n        <string>canvas.left</string>\r\n        <string>canva" +
-            "s.top</string>\r\n        </Properties>\r\n        </PropertyFilterSet>\r\n        <Pr" +
-            "opertyFilterSet>\r\n        <DisplayName>Grid/Dock</DisplayName>\r\n        <IsDefau" +
-            "lt>false</IsDefault>\r\n        <IsEditCommand>false</IsEditCommand>\r\n        <Pro" +
-            "perties>\r\n        <string>grid.</string>\r\n        <string>dockpanel.dock</string" +
-            ">\r\n        </Properties>\r\n        </PropertyFilterSet>\r\n        <PropertyFilterS" +
-            "et>\r\n        <DisplayName>Color</DisplayName>\r\n        <IsDefault>false</IsDefau" +
-            "lt>\r\n        <IsEditCommand>false</IsEditCommand>\r\n        <Properties>\r\n       " +
-            " <string>color</string>\r\n        <string>background</string>\r\n        <string>fo" +
-            "reground</string>\r\n        <string>borderbrush</string>\r\n        <string>fill</s" +
-            "tring>\r\n        <string>stroke</string>\r\n        </Properties>\r\n        </Proper" +
-            "tyFilterSet>\r\n        <PropertyFilterSet>\r\n        <DisplayName>ItemsControl</Di" +
-            "splayName>\r\n        <IsDefault>false</IsDefault>\r\n        <IsEditCommand>false</" +
-            "IsEditCommand>\r\n        <Properties>\r\n        <string>items</string>\r\n        <s" +
-            "tring>selected</string>\r\n        </Properties>\r\n        </PropertyFilterSet>\r\n  " +
-            "      </ArrayOfPropertyFilterSet>\r\n      ")]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"
+        <?xml version=""1.0"" encoding=""utf-16""?>
+        <ArrayOfPropertyFilterSet xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
+            xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+            <PropertyFilterSet>
+                <DisplayName>Layout</DisplayName>
+                <IsDefault>false</IsDefault>
+                <IsEditCommand>false</IsEditCommand>
+                <Properties>
+                    <string>width</string>
+                    <string>height</string>
+                    <string>actualwidth</string>
+                    <string>actualheight</string>
+                    <string>margin</string>
+                    <string>padding</string>
+                    <string>canvas.left</string>
+                    <string>canvas.top</string>
+                </Properties>
+            </PropertyFilterSet>
+            <PropertyFilterSet>
+                <DisplayName>Grid/Dock</DisplayName>
+                <IsDefault>false</IsDefault>
+                <IsEditCommand>false</IsEditCommand>
+                <Properties>
+                    <string>grid.</string>
+                    <string>dockpanel.dock</string>
+                </Properties>
+            </PropertyFilterSet>
+            <PropertyFilterSet>
+                <DisplayName>Color</DisplayName>
+                <IsDefault>false</IsDefault>
+                <IsEditCommand>false</IsEditCommand>
+                <Properties>
+                    <string>color</string>
+                    <string>background</string>
+                    <string>foreground</string>
+                    <string>borderbrush</string>
+                    <string>fill</string>
+                    <string>stroke</string>
+                </Properties>
+            </PropertyFilterSet>
+            <PropertyFilterSet>
+                <DisplayName>ItemsControl</DisplayName>
+                <IsDefault>false</IsDefault>
+                <IsEditCommand>false</IsEditCommand>
+                <Properties>
+                    <string>items</string>
+                    <string>selected</string>
+                </Properties>
+            </PropertyFilterSet>
+        </ArrayOfPropertyFilterSet>")]
         public PropertyFilterSet[] PropertyFilterSets
         {
             get {

--- a/Snoop/Properties/Settings.Designer.cs
+++ b/Snoop/Properties/Settings.Designer.cs
@@ -128,10 +128,8 @@ namespace Snoop.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute(@"
-        <?xml version=""1.0"" encoding=""utf-16""?>
-        <ArrayOfPropertyFilterSet xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
-            xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+        [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
+        <ArrayOfPropertyFilterSet xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
             <PropertyFilterSet>
                 <DisplayName>Layout</DisplayName>
                 <IsDefault>false</IsDefault>

--- a/Snoop/SnoopUI.xaml
+++ b/Snoop/SnoopUI.xaml
@@ -119,40 +119,68 @@ All other rights reserved.
 			<ColumnDefinition Width="2*"/>
 		</Grid.ColumnDefinitions>
 
-		<!-- Filter Combo Box -->
-		<ComboBox
-			x:Name="filterComboBox"
-			i:ComboBoxSettings.IsSnoopPart="True"
-			IsEditable="True"
-			Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"
-			Margin="2,2,22,2"
-		>
-			<ComboBoxItem>
-				<TextBlock Style="{x:Null}" Text="Clear any filter applied to the tree view"/>
-			</ComboBoxItem>
-			<ComboBoxItem>
-				<TextBlock Style="{x:Null}" Text="Show only visuals with binding errors"/>
-			</ComboBoxItem>
-			<ComboBox.ToolTip>
-				<TextBlock Style="{x:Null}" Text="Enter text in the combo box to filter the tree view by name or type"/>
-			</ComboBox.ToolTip>
-		</ComboBox>
+		<Grid>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="1*"/>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="Auto"/>
+			</Grid.ColumnDefinitions>
+			
+			<!-- Filter Combo Box -->
+			<ComboBox
+				x:Name="filterComboBox"
+				i:ComboBoxSettings.IsSnoopPart="True"
+				IsEditable="True"
+				Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"
+				Margin="2,2,2,2"
+			>
+				<ComboBoxItem>
+					<TextBlock Style="{x:Null}" Text="Clear any filter applied to the tree view"/>
+				</ComboBoxItem>
+				<ComboBoxItem>
+					<TextBlock Style="{x:Null}" Text="Show only visuals with binding errors"/>
+				</ComboBoxItem>
+				<ComboBox.ToolTip>
+					<TextBlock Style="{x:Null}" Text="Enter text in the combo box to filter the tree view by name or type"/>
+				</ComboBox.ToolTip>
+			</ComboBox>
 
-		<!-- Refresh Button -->
-		<Button
-			Style="{StaticResource refreshButton}"
-			Width="18"
-			Height="18"
-			HorizontalAlignment="Right"
-			VerticalAlignment="Center"
-			Margin="0,2,2,2"
-			Command="{x:Static local:SnoopUI.RefreshCommand}"
-		>
-			<Image Source="{StaticResource reloadDrawingImage}"/>
-			<Button.ToolTip>
-				<TextBlock Style="{x:Null}" Text="Refresh the tree view"/>
-			</Button.ToolTip>
-		</Button>
+			<!-- Refresh Button -->
+			<Button
+				Style="{StaticResource refreshButton}"
+				Width="18"
+				Height="18"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Margin="2,2,2,2"
+				Command="{x:Static local:SnoopUI.RefreshCommand}"
+				Grid.Column="1"
+			>
+				<Image Source="{StaticResource reloadDrawingImage}"/>
+				<Button.ToolTip>
+					<TextBlock Style="{x:Null}" Text="Refresh the tree view"/>
+				</Button.ToolTip>
+			</Button>
+
+			<!-- Export Button -->
+			<Button
+				Style="{StaticResource refreshButton}"
+				Width="18"
+				Height="18"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Margin="2,2,2,2"
+				Command="{x:Static local:SnoopUI.ExportCommand}"
+				Grid.Column="2"
+			>
+				<Image Source="{StaticResource exportDrawingImage}"
+					   Margin="1
+					   "/>
+				<Button.ToolTip>
+					<TextBlock Style="{x:Null}" Text="Export tree as XML"/>
+				</Button.ToolTip>
+			</Button>
+		</Grid>
 
 		<!-- Visual Tree TreeView -->
 		<local:ProperTreeView

--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -1179,14 +1179,21 @@ namespace Snoop
 				{
 					RootVisual = elem;
 				}
-				Rect bounds = elem.TransformToAncestor(RootVisual).TransformBounds(VisualTreeHelper.GetDescendantBounds(elem));
-				if (!bounds.IsEmpty)
+				try
 				{
-					Writer.Write(baseIndent);
-					WriteProperty("x-BoundsInClientArea", bounds.ToString());
-					//bounds.Offset(new Vector(0, SystemParameters.WindowCaptionHeight));
-					//Writer.Write(baseIndent);
-					//WriteProperty("x-BoundsInWindow", bounds.ToString());
+					Rect bounds = elem.TransformToAncestor(RootVisual).TransformBounds(VisualTreeHelper.GetDescendantBounds(elem));
+					if (!bounds.IsEmpty)
+					{
+						Writer.Write(baseIndent);
+						WriteProperty("x-BoundsInClientArea", bounds.ToString());
+						//bounds.Offset(new Vector(0, SystemParameters.WindowCaptionHeight));
+						//Writer.Write(baseIndent);
+						//WriteProperty("x-BoundsInWindow", bounds.ToString());
+					}
+				}
+				catch (Exception)
+				{
+					// In case this element is not a child of the root. Ignore.
 				}
 			}
 			foreach (VisualTreeItem child in item.Children)

--- a/Snoop/VisualTreeItem.cs
+++ b/Snoop/VisualTreeItem.cs
@@ -248,6 +248,13 @@ namespace Snoop
 		}
 
 
+		/// <summary>
+		/// The name of this VisualTreeItem
+		/// </summary>
+		public string Name
+		{
+			get { return this.name; }
+		}
 		private string name;
 		private string nameLower = string.Empty;
 		private string typeNameLower = string.Empty;


### PR DESCRIPTION
This addresses #38.

This adds an "export" button on the SnoopUI window next to the refresh button. It creates files named `%processname% - [%pid%].xml` on the desktop, in an ad hoc XML format.

Things to be improved:
- Better output format
- Customizing output location
