### PR TITLE
MenuMode fix

### DIFF
--- a/Snoop/Snoop.csproj
+++ b/Snoop/Snoop.csproj
@@ -174,7 +174,7 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <Content Include="Scripts\Snoop.psm1">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="VisualTreeItem.cd" />
   </ItemGroup>

--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -471,6 +471,8 @@ namespace Snoop
 
 			Show();
 			Activate();
+
+			InputManager.Current.PushMenuMode(PresentationSource.FromVisual(this));
 		}
 		public void Inspect(object root, Window ownerWindow)
 		{
@@ -598,6 +600,7 @@ namespace Snoop
 			this.CurrentSelection = null;
 
 			InputManager.Current.PreProcessInput -= this.HandlePreProcessInput;
+			InputManager.Current.PopMenuMode(PresentationSource.FromVisual(this));
 			EventsListener.Stop();
 
 			EditedPropertiesHelper.DumpObjectsWithEditedProperties();


### PR DESCRIPTION
When Snooping Visual Studio, we need to push MenuMode when showing the Snoop in-proc UI, and pop MenuMode when closing it. Otherwise keystrokes such as Enter and Backspace will go to the VS main window instead of Snoop, which makes it impossible to use the powershell prompt and other things.

Try snooping Visual Studio, use Ctrl+Shift to select some element, then type $selected ENTER into powershell. Sometimes it would work but for me it didn't and after investigating why the keystrokes were routed into VS main window I found this solution.

More info:
http://blogs.msdn.com/b/visualstudio/archive/2010/03/09/wpf-in-visual-studio-2010-part-3-focus-and-activation.aspx

Bonus: The snoop project was being rebuilt every time even if nothing had changed. I've changed the Copy Always to Preserve Newest on a file to fix that. More info:
http://blogs.msdn.com/b/kirillosenkov/archive/2014/08/04/how-to-investigate-rebuilding-in-visual-studio-when-nothing-has-changed.aspx
