### PR TITLE
Fixed the hang on priority binding.

### DIFF
--- a/Snoop/PropertyInformation.cs
+++ b/Snoop/PropertyInformation.cs
@@ -584,7 +584,7 @@ namespace Snoop
 				{
 					this.isDatabound = true;
 
-					if (expression.HasError || expression.Status != BindingStatus.Active)
+                    if (expression.HasError || expression.Status != BindingStatus.Active && !(expression is PriorityBindingExpression))
 					{
 						this.isInvalidBinding = true;
 


### PR DESCRIPTION
This is a quick fix ... that addresses the hang that occurs when Snooping something that has a PriorityBinding. I wonder if there is a better way to fix this ... but let's merge this fix right away so that Snoop doesn't hang.