### PR TITLE
Keep correct window size on high dpi displays

### DIFF
--- a/Snoop/AppChooser.xaml.cs
+++ b/Snoop/AppChooser.xaml.cs
@@ -96,12 +96,19 @@ namespace Snoop
 			try
 			{
 				// load the window placement details from the user settings.
-				WINDOWPLACEMENT wp = (WINDOWPLACEMENT)Properties.Settings.Default.AppChooserWindowPlacement;
-				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-				wp.flags = 0;
-				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				IntPtr hwnd = new WindowInteropHelper(this).Handle;
-				Win32.SetWindowPlacement(hwnd, ref wp);
+				WINDOWPLACEMENT wp = Properties.Settings.Default.AppChooserWindowPlacement;
+				if (wp.length > 0)
+				{
+					this.SetPlacement(wp);
+				}
+				else
+				{
+					// first time up: move to the corner, keep correct window size
+					WindowStartupLocation = System.Windows.WindowStartupLocation.Manual;
+					WindowState = System.Windows.WindowState.Normal;
+					Top = 0;
+					Left = 0;
+				}
 			}
 			catch
 			{
@@ -112,11 +119,12 @@ namespace Snoop
 			base.OnClosing(e);
 
 			// persist the window placement details to the user settings.
-			WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
-			IntPtr hwnd = new WindowInteropHelper(this).Handle;
-			Win32.GetWindowPlacement(hwnd, out wp);
-			Properties.Settings.Default.AppChooserWindowPlacement = wp;
-			Properties.Settings.Default.Save();
+			var placement = this.GetPlacement();
+			if (placement.HasValue)
+			{
+				Properties.Settings.Default.AppChooserWindowPlacement = placement.Value;
+				Properties.Settings.Default.Save();
+			}
 		}
 
 

--- a/Snoop/Properties/Settings.Designer.cs
+++ b/Snoop/Properties/Settings.Designer.cs
@@ -29,7 +29,7 @@ namespace Snoop.Properties {
         [global::System.Configuration.DefaultSettingValueAttribute(
       @"<?xml version=""1.0"" encoding=""utf-16""?>
         <WINDOWPLACEMENT xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-        <length>44</length>
+        <length>0</length>
         <flags>0</flags>
         <showCmd>1</showCmd>
         <minPosition>
@@ -63,7 +63,7 @@ namespace Snoop.Properties {
         [global::System.Configuration.DefaultSettingValueAttribute(
       @"<?xml version=""1.0"" encoding=""utf-16""?>
         <WINDOWPLACEMENT xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-        <length>44</length>
+        <length>0</length>
         <flags>0</flags>
         <showCmd>1</showCmd>
         <minPosition>
@@ -97,7 +97,7 @@ namespace Snoop.Properties {
         [global::System.Configuration.DefaultSettingValueAttribute(
       @"<?xml version=""1.0"" encoding=""utf-16""?>
         <WINDOWPLACEMENT xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-        <length>44</length>
+        <length>0</length>
         <flags>0</flags>
         <showCmd>1</showCmd>
         <minPosition>

--- a/Snoop/Properties/Settings.settings
+++ b/Snoop/Properties/Settings.settings
@@ -6,7 +6,7 @@
       <Value Profile="(Default)">
         &lt;?xml version="1.0" encoding="utf-16"?&gt;
         &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
+        &lt;length&gt;0&lt;/length&gt;
         &lt;flags&gt;0&lt;/flags&gt;
         &lt;showCmd&gt;1&lt;/showCmd&gt;
         &lt;minPosition&gt;
@@ -30,7 +30,7 @@
       <Value Profile="(Default)">
         &lt;?xml version="1.0" encoding="utf-16"?&gt;
         &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
+        &lt;length&gt;0&lt;/length&gt;
         &lt;flags&gt;0&lt;/flags&gt;
         &lt;showCmd&gt;1&lt;/showCmd&gt;
         &lt;minPosition&gt;
@@ -54,7 +54,7 @@
       <Value Profile="(Default)">
         &lt;?xml version="1.0" encoding="utf-16"?&gt;
         &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
+        &lt;length&gt;0&lt;/length&gt;
         &lt;flags&gt;0&lt;/flags&gt;
         &lt;showCmd&gt;1&lt;/showCmd&gt;
         &lt;minPosition&gt;

--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -562,12 +562,18 @@ namespace Snoop
 			try
 			{
 				// load the window placement details from the user settings.
-				WINDOWPLACEMENT wp = (WINDOWPLACEMENT)Properties.Settings.Default.SnoopUIWindowPlacement;
-				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-				wp.flags = 0;
-				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				IntPtr hwnd = new WindowInteropHelper(this).Handle;
-				Win32.SetWindowPlacement(hwnd, ref wp);
+				WINDOWPLACEMENT wp = Properties.Settings.Default.SnoopUIWindowPlacement;
+				if (wp.length > 0)
+				{
+					this.SetPlacement(wp);
+				}
+				else
+				{
+					// first time up: move to the corner
+					WindowStartupLocation = WindowStartupLocation.Manual;
+					Top = 20;
+					Left = 0;
+				}
 
 				// load whether all properties are shown by default
 				this.PropertyGrid.ShowDefaults = Properties.Settings.Default.ShowDefaults;
@@ -603,10 +609,13 @@ namespace Snoop
 			EditedPropertiesHelper.DumpObjectsWithEditedProperties();
 
 			// persist the window placement details to the user settings.
-			WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
-			IntPtr hwnd = new WindowInteropHelper(this).Handle;
-			Win32.GetWindowPlacement(hwnd, out wp);
-			Properties.Settings.Default.SnoopUIWindowPlacement = wp;
+			var wp = this.GetPlacement();
+			if (wp.HasValue)
+				Properties.Settings.Default.SnoopUIWindowPlacement = wp.Value;
+//			WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
+//			IntPtr hwnd = new WindowInteropHelper(this).Handle;
+//			Win32.GetWindowPlacement(hwnd, out wp);
+//			Properties.Settings.Default.SnoopUIWindowPlacement = wp;
 
 			// persist whether all properties are shown by default
 			Properties.Settings.Default.ShowDefaults = this.PropertyGrid.ShowDefaults;

--- a/Snoop/WindowPlacement.cs
+++ b/Snoop/WindowPlacement.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
 
 namespace Snoop
 {
@@ -67,5 +69,45 @@ namespace Snoop
 
 		public const int SW_SHOWNORMAL = 1;
 		public const int SW_SHOWMINIMIZED = 2;
+	}
+
+	public static class WindowPlacement
+	{
+		// Win32 API declarations to set and get window placement
+		[DllImport("user32.dll")]
+		static extern bool SetWindowPlacement(IntPtr hWnd, [In] ref WINDOWPLACEMENT lpwndpl);
+
+		[DllImport("user32.dll")]
+		static extern bool GetWindowPlacement(IntPtr hWnd, out WINDOWPLACEMENT lpwndpl);
+
+		const int SW_SHOWNORMAL = 1;
+		const int SW_SHOWMINIMIZED = 2;
+
+		public static void SetPlacement(this Window window, WINDOWPLACEMENT wp)
+		{
+			try
+			{
+				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+				wp.flags = 0;
+				if (wp.showCmd == SW_SHOWMINIMIZED)
+					wp.showCmd = SW_SHOWNORMAL;
+				IntPtr hwnd = new WindowInteropHelper(window).Handle;
+				SetWindowPlacement(hwnd, ref wp);
+			}
+			catch (Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine(ex.Message);
+			}
+		}
+
+		public static WINDOWPLACEMENT? GetPlacement(this Window window)
+		{
+			WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
+			IntPtr hwnd = new WindowInteropHelper(window).Handle;
+			if (GetWindowPlacement(hwnd, out wp))
+				return wp;
+			else
+				return null;
+		}
 	}
 }

--- a/Snoop/Zoomer.xaml.cs
+++ b/Snoop/Zoomer.xaml.cs
@@ -149,12 +149,18 @@ namespace Snoop
 			try
 			{
 				// load the window placement details from the user settings.
-				WINDOWPLACEMENT wp = (WINDOWPLACEMENT)Properties.Settings.Default.ZoomerWindowPlacement;
-				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-				wp.flags = 0;
-				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				IntPtr hwnd = new WindowInteropHelper(this).Handle;
-				Win32.SetWindowPlacement(hwnd, ref wp);
+				WINDOWPLACEMENT wp = Properties.Settings.Default.ZoomerWindowPlacement;
+				if (wp.length > 0)
+				{
+					this.SetPlacement(wp);
+				}
+				else
+				{
+					// first time up: move to the corner
+					WindowStartupLocation = WindowStartupLocation.Manual;
+					Top = 20;
+					Left = 0;
+				}
 			}
 			catch
 			{

--- a/Snoop/app.config
+++ b/Snoop/app.config
@@ -16,7 +16,7 @@
                 <value>
         &lt;?xml version="1.0" encoding="utf-16"?&gt;
         &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
+        &lt;length&gt;0&lt;/length&gt;
         &lt;flags&gt;0&lt;/flags&gt;
         &lt;showCmd&gt;1&lt;/showCmd&gt;
         &lt;minPosition&gt;
@@ -40,7 +40,7 @@
                 <value>
         &lt;?xml version="1.0" encoding="utf-16"?&gt;
         &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
+        &lt;length&gt;0&lt;/length&gt;
         &lt;flags&gt;0&lt;/flags&gt;
         &lt;showCmd&gt;1&lt;/showCmd&gt;
         &lt;minPosition&gt;
@@ -64,7 +64,7 @@
                 <value>
         &lt;?xml version="1.0" encoding="utf-16"?&gt;
         &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
+        &lt;length&gt;0&lt;/length&gt;
         &lt;flags&gt;0&lt;/flags&gt;
         &lt;showCmd&gt;1&lt;/showCmd&gt;
         &lt;minPosition&gt;


### PR DESCRIPTION
On high dpi monitors Snoop window is cut in half with no way to resize it. That's because it uses canned WINDOWPLACEMENT to restore size and that struct stores physical pixel sizes.
So the idea is *not* to use them initially. That way size defined in XAML will be preserved when windows are open for the first time.