### PR TITLE
Changed the default IsActive property on the preview panel to true

### DIFF
--- a/Snoop/Previewer.xaml.cs
+++ b/Snoop/Previewer.xaml.cs
@@ -84,7 +84,7 @@ namespace Snoop
 				typeof(Previewer),
 				new FrameworkPropertyMetadata
 				(
-					(bool)false,
+					(bool)true,
 					new PropertyChangedCallback(OnIsActiveChanged)
 				)
 			);


### PR DESCRIPTION
Changed the default IsActive property on the preview panel to true, meaning the preview area is enabled by default.