### PR TITLE
#53 use InvariantCulture to display values

### DIFF
--- a/Snoop/ValueEditors/StandardValueEditor.cs
+++ b/Snoop/ValueEditors/StandardValueEditor.cs
@@ -6,6 +6,8 @@
 using System.Windows;
 using System;
 using System.ComponentModel;
+using System.Globalization;
+using System.Threading;
 using System.Windows.Data;
 
 namespace Snoop
@@ -84,8 +86,14 @@ namespace Snoop
 			this.isUpdatingValue = true;
 
 			object value = this.Value;
-			if (value != null)
-				this.StringValue = value.ToString();
+		    if (value != null)
+		    {
+		        var fallbackCulture = Thread.CurrentThread.CurrentCulture;
+                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+                this.StringValue = value.ToString();
+		        Thread.CurrentThread.CurrentCulture = fallbackCulture;
+		    }
+				
 			else
 				this.StringValue = string.Empty;
 

--- a/Snoop/ValueEditors/StandardValueEditor.cs
+++ b/Snoop/ValueEditors/StandardValueEditor.cs
@@ -88,10 +88,17 @@ namespace Snoop
 			object value = this.Value;
 		    if (value != null)
 		    {
-		        var fallbackCulture = Thread.CurrentThread.CurrentCulture;
-                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-                this.StringValue = value.ToString();
-		        Thread.CurrentThread.CurrentCulture = fallbackCulture;
+                var fallbackCulture = Thread.CurrentThread.CurrentCulture;
+
+                try
+                {
+		            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+		            this.StringValue = value.ToString();
+		        }
+		        finally
+		        {
+                    Thread.CurrentThread.CurrentCulture = fallbackCulture;
+                }
 		    }
 				
 			else


### PR DESCRIPTION
Unfortunately there is no generic ToString overload that accepts a CultureInfo. To circumvent this problem, I have to highjack the current threads CurrentCulture for a short period in time, generate the string value and switch the culture back.
There may be other places where it would be better to use the InvariantCulture, but this is the one I was primarily concerned about.

Affected Property types are at least:
- DateTime values
- any numbers with a decimal separator (float, double, decimal)
- anything that uses those numbers as part of their toString() implementation, like Geometry.

Tackles issue #53 
