### PR TITLE
Default window placements should be null

### DIFF
--- a/Snoop/AppChooser.xaml.cs
+++ b/Snoop/AppChooser.xaml.cs
@@ -93,35 +93,17 @@ namespace Snoop
 		{
 			base.OnSourceInitialized(e);
 
-		    if (Properties.Settings.Default.AppChooserWindowPlacement.HasValue == false)
-		    {
-		        return;
-		    }
-
-		    try
-			{
-				// load the window placement details from the user settings.
-				var wp = Properties.Settings.Default.AppChooserWindowPlacement.Value;
-				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-				wp.flags = 0;
-				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				var hwnd = new WindowInteropHelper(this).Handle;
-				Win32.SetWindowPlacement(hwnd, ref wp);
-			}
-			catch
-			{
-			}
+		    // load the window placement details from the user settings.
+		    SnoopWindowUtils.LoadWindowPlacement(this, Properties.Settings.Default.AppChooserWindowPlacement);
 		}
 
 		protected override void OnClosing(CancelEventArgs e)
 		{
 			base.OnClosing(e);
 
-			// persist the window placement details to the user settings.
-			var wp = new WINDOWPLACEMENT();
-			var hwnd = new WindowInteropHelper(this).Handle;
-			Win32.GetWindowPlacement(hwnd, out wp);
-			Properties.Settings.Default.AppChooserWindowPlacement = wp;
+		    // persist the window placement details to the user settings.
+            SnoopWindowUtils.SaveWindowPlacement(this, wp => Properties.Settings.Default.AppChooserWindowPlacement = wp);
+		
 			Properties.Settings.Default.Save();
 		}
 

--- a/Snoop/AppChooser.xaml.cs
+++ b/Snoop/AppChooser.xaml.cs
@@ -93,32 +93,37 @@ namespace Snoop
 		{
 			base.OnSourceInitialized(e);
 
-			try
+		    if (Properties.Settings.Default.AppChooserWindowPlacement.HasValue == false)
+		    {
+		        return;
+		    }
+
+		    try
 			{
 				// load the window placement details from the user settings.
-				WINDOWPLACEMENT wp = (WINDOWPLACEMENT)Properties.Settings.Default.AppChooserWindowPlacement;
+				var wp = Properties.Settings.Default.AppChooserWindowPlacement.Value;
 				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
 				wp.flags = 0;
 				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				IntPtr hwnd = new WindowInteropHelper(this).Handle;
+				var hwnd = new WindowInteropHelper(this).Handle;
 				Win32.SetWindowPlacement(hwnd, ref wp);
 			}
 			catch
 			{
 			}
 		}
+
 		protected override void OnClosing(CancelEventArgs e)
 		{
 			base.OnClosing(e);
 
 			// persist the window placement details to the user settings.
-			WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
-			IntPtr hwnd = new WindowInteropHelper(this).Handle;
+			var wp = new WINDOWPLACEMENT();
+			var hwnd = new WindowInteropHelper(this).Handle;
 			Win32.GetWindowPlacement(hwnd, out wp);
 			Properties.Settings.Default.AppChooserWindowPlacement = wp;
 			Properties.Settings.Default.Save();
 		}
-
 
 		private bool HasProcess(Process process)
 		{

--- a/Snoop/Properties/Settings.Designer.cs
+++ b/Snoop/Properties/Settings.Designer.cs
@@ -23,112 +23,43 @@ namespace Snoop.Properties {
                 return defaultInstance;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute(
-      @"<?xml version=""1.0"" encoding=""utf-16""?>
-        <WINDOWPLACEMENT xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-        <length>44</length>
-        <flags>0</flags>
-        <showCmd>1</showCmd>
-        <minPosition>
-        <X>-1</X>
-        <Y>-1</Y>
-        </minPosition>
-        <maxPosition>
-        <X>-1</X>
-        <Y>-1</Y>
-        </maxPosition>
-        <normalPosition>
-        <Left>10</Left>
-        <Top>10</Top>
-        <Right>650</Right>
-        <Bottom>490</Bottom>
-        </normalPosition>
-        </WINDOWPLACEMENT>
-      ")]
-        public WINDOWPLACEMENT SnoopUIWindowPlacement
-        {
-            get
-            {
-                return ((WINDOWPLACEMENT)(this["SnoopUIWindowPlacement"]));
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public WINDOWPLACEMENT? SnoopUIWindowPlacement {
+            get {
+                return ((WINDOWPLACEMENT?)(this["SnoopUIWindowPlacement"]));
             }
-            set
-            {
+            set {
                 this["SnoopUIWindowPlacement"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute(@"
-        <?xml version=""1.0"" encoding=""utf-16""?>
-        <WINDOWPLACEMENT xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-        <length>44</length>
-        <flags>0</flags>
-        <showCmd>1</showCmd>
-        <minPosition>
-        <X>-1</X>
-        <Y>-1</Y>
-        </minPosition>
-        <maxPosition>
-        <X>-1</X>
-        <Y>-1</Y>
-        </maxPosition>
-        <normalPosition>
-        <Left>10</Left>
-        <Top>10</Top>
-        <Right>541</Right>
-        <Bottom>36</Bottom>
-        </normalPosition>
-        </WINDOWPLACEMENT>
-      ")]
-        public WINDOWPLACEMENT AppChooserWindowPlacement {
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public WINDOWPLACEMENT? AppChooserWindowPlacement {
             get {
-                return ((WINDOWPLACEMENT)(this["AppChooserWindowPlacement"]));
+                return ((WINDOWPLACEMENT?)(this["AppChooserWindowPlacement"]));
             }
             set {
                 this["AppChooserWindowPlacement"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute(
-      @"<?xml version=""1.0"" encoding=""utf-16""?>
-        <WINDOWPLACEMENT xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-        <length>44</length>
-        <flags>0</flags>
-        <showCmd>1</showCmd>
-        <minPosition>
-        <X>-1</X>
-        <Y>-1</Y>
-        </minPosition>
-        <maxPosition>
-        <X>-1</X>
-        <Y>-1</Y>
-        </maxPosition>
-        <normalPosition>
-        <Left>10</Left>
-        <Top>10</Top>
-        <Right>541</Right>
-        <Bottom>36</Bottom>
-        </normalPosition>
-        </WINDOWPLACEMENT>
-      ")]
-        public WINDOWPLACEMENT ZoomerWindowPlacement
-        {
-            get
-            {
-                return ((WINDOWPLACEMENT)(this["ZoomerWindowPlacement"]));
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public WINDOWPLACEMENT? ZoomerWindowPlacement {
+            get {
+                return ((WINDOWPLACEMENT?)(this["ZoomerWindowPlacement"]));
             }
-            set
-            {
+            set {
                 this["ZoomerWindowPlacement"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n        <ArrayOfPropertyFilter" +

--- a/Snoop/Properties/Settings.settings
+++ b/Snoop/Properties/Settings.settings
@@ -3,76 +3,13 @@
   <Profiles />
   <Settings>
     <Setting Name="SnoopUIWindowPlacement" Type="System.String" Scope="User">
-      <Value Profile="(Default)">
-        &lt;?xml version="1.0" encoding="utf-16"?&gt;
-        &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
-        &lt;flags&gt;0&lt;/flags&gt;
-        &lt;showCmd&gt;1&lt;/showCmd&gt;
-        &lt;minPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/minPosition&gt;
-        &lt;maxPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/maxPosition&gt;
-        &lt;normalPosition&gt;
-        &lt;Left&gt;10&lt;/Left&gt;
-        &lt;Top&gt;10&lt;/Top&gt;
-        &lt;Right&gt;650&lt;/Right&gt;
-        &lt;Bottom&gt;490&lt;/Bottom&gt;
-        &lt;/normalPosition&gt;
-        &lt;/WINDOWPLACEMENT&gt;
-      </Value>
+      <Value Profile="(Default)"></Value>
     </Setting>
     <Setting Name="AppChooserWindowPlacement" Type="System.String" Scope="User">
-      <Value Profile="(Default)">
-        &lt;?xml version="1.0" encoding="utf-16"?&gt;
-        &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
-        &lt;flags&gt;0&lt;/flags&gt;
-        &lt;showCmd&gt;1&lt;/showCmd&gt;
-        &lt;minPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/minPosition&gt;
-        &lt;maxPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/maxPosition&gt;
-        &lt;normalPosition&gt;
-        &lt;Left&gt;10&lt;/Left&gt;
-        &lt;Top&gt;10&lt;/Top&gt;
-        &lt;Right&gt;541&lt;/Right&gt;
-        &lt;Bottom&gt;36&lt;/Bottom&gt;
-        &lt;/normalPosition&gt;
-        &lt;/WINDOWPLACEMENT&gt;
-      </Value>
+      <Value Profile="(Default)"></Value>
     </Setting>
     <Setting Name="ZoomerWindowPlacement" Type="System.String" Scope="User">
-      <Value Profile="(Default)">
-        &lt;?xml version="1.0" encoding="utf-16"?&gt;
-        &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
-        &lt;flags&gt;0&lt;/flags&gt;
-        &lt;showCmd&gt;1&lt;/showCmd&gt;
-        &lt;minPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/minPosition&gt;
-        &lt;maxPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/maxPosition&gt;
-        &lt;normalPosition&gt;
-        &lt;Left&gt;10&lt;/Left&gt;
-        &lt;Top&gt;10&lt;/Top&gt;
-        &lt;Right&gt;541&lt;/Right&gt;
-        &lt;Bottom&gt;36&lt;/Bottom&gt;
-        &lt;/normalPosition&gt;
-        &lt;/WINDOWPLACEMENT&gt;
-      </Value>
+      <Value Profile="(Default)"></Value>
     </Setting>
     <Setting Name="PropertyFilterSets" Type="System.String" Scope="User">
       <Value Profile="(Default)">

--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -559,24 +559,8 @@ namespace Snoop
 		    // load whether the previewer is shown by default
 		    this.PreviewArea.IsActive = Properties.Settings.Default.ShowPreviewer;
 
-		    if (Properties.Settings.Default.SnoopUIWindowPlacement.HasValue == false)
-		    {
-		        return;
-		    }
-
-		    try
-			{
-				// load the window placement details from the user settings.
-				var wp = Properties.Settings.Default.SnoopUIWindowPlacement.Value;
-				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-				wp.flags = 0;
-				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				var hwnd = new WindowInteropHelper(this).Handle;
-				Win32.SetWindowPlacement(hwnd, ref wp);
-			}
-			catch
-			{
-			}
+		    // load the window placement details from the user settings.
+            SnoopWindowUtils.LoadWindowPlacement(this, Properties.Settings.Default.SnoopUIWindowPlacement);
 		}
 
 		/// <summary>
@@ -591,11 +575,8 @@ namespace Snoop
 			InputManager.Current.PreProcessInput -= this.HandlePreProcessInput;
 			EventsListener.Stop();
 
-			// persist the window placement details to the user settings.
-			var wp = new WINDOWPLACEMENT();
-			var hwnd = new WindowInteropHelper(this).Handle;
-			Win32.GetWindowPlacement(hwnd, out wp);
-			Properties.Settings.Default.SnoopUIWindowPlacement = wp;
+		    // persist the window placement details to the user settings.
+		    SnoopWindowUtils.SaveWindowPlacement(this, wp => Properties.Settings.Default.SnoopUIWindowPlacement = wp);
 
 			// persist whether all properties are shown by default
 			Properties.Settings.Default.ShowDefaults = this.PropertyGrid.ShowDefaults;

--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -553,26 +553,32 @@ namespace Snoop
 		{
 			base.OnSourceInitialized(e);
 
-			try
+		    // load whether all properties are shown by default
+		    this.PropertyGrid.ShowDefaults = Properties.Settings.Default.ShowDefaults;
+
+		    // load whether the previewer is shown by default
+		    this.PreviewArea.IsActive = Properties.Settings.Default.ShowPreviewer;
+
+		    if (Properties.Settings.Default.SnoopUIWindowPlacement.HasValue == false)
+		    {
+		        return;
+		    }
+
+		    try
 			{
 				// load the window placement details from the user settings.
-				WINDOWPLACEMENT wp = (WINDOWPLACEMENT)Properties.Settings.Default.SnoopUIWindowPlacement;
+				var wp = Properties.Settings.Default.SnoopUIWindowPlacement.Value;
 				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
 				wp.flags = 0;
 				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				IntPtr hwnd = new WindowInteropHelper(this).Handle;
+				var hwnd = new WindowInteropHelper(this).Handle;
 				Win32.SetWindowPlacement(hwnd, ref wp);
-
-				// load whether all properties are shown by default
-				this.PropertyGrid.ShowDefaults = Properties.Settings.Default.ShowDefaults;
-
-				// load whether the previewer is shown by default
-				this.PreviewArea.IsActive = Properties.Settings.Default.ShowPreviewer;
 			}
 			catch
 			{
 			}
 		}
+
 		/// <summary>
 		/// Cleanup when closing the window.
 		/// </summary>
@@ -586,8 +592,8 @@ namespace Snoop
 			EventsListener.Stop();
 
 			// persist the window placement details to the user settings.
-			WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
-			IntPtr hwnd = new WindowInteropHelper(this).Handle;
+			var wp = new WINDOWPLACEMENT();
+			var hwnd = new WindowInteropHelper(this).Handle;
 			Win32.GetWindowPlacement(hwnd, out wp);
 			Properties.Settings.Default.SnoopUIWindowPlacement = wp;
 

--- a/Snoop/SnoopWindowUtils.cs
+++ b/Snoop/SnoopWindowUtils.cs
@@ -4,14 +4,15 @@
 // All other rights reserved.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Windows;
 using Snoop.Infrastructure;
 
 namespace Snoop
 {
-	public static class SnoopWindowUtils
+    using System.Runtime.InteropServices;
+    using System.Windows.Interop;
+
+    public static class SnoopWindowUtils
 	{
 		public static Window FindOwnerWindow()
 		{
@@ -73,5 +74,36 @@ namespace Snoop
 
 			return ownerWindow;
 		}
+
+	    public static void LoadWindowPlacement(Window window, WINDOWPLACEMENT? windowPlacement)
+	    {
+	        if (windowPlacement.HasValue == false)
+	        {
+	            return;
+	        }
+
+	        try
+	        {
+	            // load the window placement details from the user settings.
+	            var wp = windowPlacement.Value;
+	            wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+	            wp.flags = 0;
+	            wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
+	            var hwnd = new WindowInteropHelper(window).Handle;
+	            Win32.SetWindowPlacement(hwnd, ref wp);
+	        }
+	        catch
+	        {
+	        }
+	    }
+
+	    public static void SaveWindowPlacement(Window window, Action<WINDOWPLACEMENT> saveAction)
+	    {
+	        WINDOWPLACEMENT windowPlacement;
+	        var hwnd = new WindowInteropHelper(window).Handle;
+	        Win32.GetWindowPlacement(hwnd, out windowPlacement);
+
+	        saveAction(windowPlacement);
+	    }
 	}
 }

--- a/Snoop/Zoomer.xaml.cs
+++ b/Snoop/Zoomer.xaml.cs
@@ -146,25 +146,8 @@ namespace Snoop
 		{
 			base.OnSourceInitialized(e);
 
-		    if (Properties.Settings.Default.ZoomerWindowPlacement.HasValue == false)
-		    {
-		        return;
-		    }
-
-		    try
-			{
-				// load the window placement details from the user settings.
-				var wp = Properties.Settings.Default.ZoomerWindowPlacement.Value;
-
-			    wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-				wp.flags = 0;
-				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				var hwnd = new WindowInteropHelper(this).Handle;
-				Win32.SetWindowPlacement(hwnd, ref wp);
-			}
-			catch
-			{
-			}
+		    // load the window placement details from the user settings.
+		    SnoopWindowUtils.LoadWindowPlacement(this, Properties.Settings.Default.ZoomerWindowPlacement);
 		}		
 
 		protected override void OnClosing(CancelEventArgs e)
@@ -173,12 +156,8 @@ namespace Snoop
 
 			this.Viewbox.Child = null;
 
-			// persist the window placement details to the user settings.
-			var wp = new WINDOWPLACEMENT();
-			var hwnd = new WindowInteropHelper(this).Handle;
-			Win32.GetWindowPlacement(hwnd, out wp);
-			Properties.Settings.Default.ZoomerWindowPlacement = wp;
-			Properties.Settings.Default.Save();
+		    // persist the window placement details to the user settings.
+		    SnoopWindowUtils.SaveWindowPlacement(this, wp => Properties.Settings.Default.ZoomerWindowPlacement = wp);
 
 			SnoopPartsRegistry.RemoveSnoopVisualTreeRoot(this);
 		}

--- a/Snoop/Zoomer.xaml.cs
+++ b/Snoop/Zoomer.xaml.cs
@@ -146,22 +146,26 @@ namespace Snoop
 		{
 			base.OnSourceInitialized(e);
 
-			try
+		    if (Properties.Settings.Default.ZoomerWindowPlacement.HasValue == false)
+		    {
+		        return;
+		    }
+
+		    try
 			{
 				// load the window placement details from the user settings.
-				WINDOWPLACEMENT wp = (WINDOWPLACEMENT)Properties.Settings.Default.ZoomerWindowPlacement;
-				wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+				var wp = Properties.Settings.Default.ZoomerWindowPlacement.Value;
+
+			    wp.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
 				wp.flags = 0;
 				wp.showCmd = (wp.showCmd == Win32.SW_SHOWMINIMIZED ? Win32.SW_SHOWNORMAL : wp.showCmd);
-				IntPtr hwnd = new WindowInteropHelper(this).Handle;
+				var hwnd = new WindowInteropHelper(this).Handle;
 				Win32.SetWindowPlacement(hwnd, ref wp);
 			}
 			catch
 			{
 			}
-		}
-
-		
+		}		
 
 		protected override void OnClosing(CancelEventArgs e)
 		{
@@ -170,8 +174,8 @@ namespace Snoop
 			this.Viewbox.Child = null;
 
 			// persist the window placement details to the user settings.
-			WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
-			IntPtr hwnd = new WindowInteropHelper(this).Handle;
+			var wp = new WINDOWPLACEMENT();
+			var hwnd = new WindowInteropHelper(this).Handle;
 			Win32.GetWindowPlacement(hwnd, out wp);
 			Properties.Settings.Default.ZoomerWindowPlacement = wp;
 			Properties.Settings.Default.Save();

--- a/Snoop/app.config
+++ b/Snoop/app.config
@@ -8,76 +8,13 @@
     <userSettings>
         <Snoop.Properties.Settings>
             <setting name="SnoopUIWindowPlacement" serializeAs="String">
-                <value>
-        &lt;?xml version="1.0" encoding="utf-16"?&gt;
-        &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
-        &lt;flags&gt;0&lt;/flags&gt;
-        &lt;showCmd&gt;1&lt;/showCmd&gt;
-        &lt;minPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/minPosition&gt;
-        &lt;maxPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/maxPosition&gt;
-        &lt;normalPosition&gt;
-        &lt;Left&gt;10&lt;/Left&gt;
-        &lt;Top&gt;10&lt;/Top&gt;
-        &lt;Right&gt;650&lt;/Right&gt;
-        &lt;Bottom&gt;490&lt;/Bottom&gt;
-        &lt;/normalPosition&gt;
-        &lt;/WINDOWPLACEMENT&gt;
-      </value>
+                <value></value>
             </setting>
             <setting name="AppChooserWindowPlacement" serializeAs="String">
-                <value>
-        &lt;?xml version="1.0" encoding="utf-16"?&gt;
-        &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
-        &lt;flags&gt;0&lt;/flags&gt;
-        &lt;showCmd&gt;1&lt;/showCmd&gt;
-        &lt;minPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/minPosition&gt;
-        &lt;maxPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/maxPosition&gt;
-        &lt;normalPosition&gt;
-        &lt;Left&gt;10&lt;/Left&gt;
-        &lt;Top&gt;10&lt;/Top&gt;
-        &lt;Right&gt;541&lt;/Right&gt;
-        &lt;Bottom&gt;36&lt;/Bottom&gt;
-        &lt;/normalPosition&gt;
-        &lt;/WINDOWPLACEMENT&gt;
-      </value>
+                <value></value>
             </setting>
             <setting name="ZoomerWindowPlacement" serializeAs="String">
-                <value>
-        &lt;?xml version="1.0" encoding="utf-16"?&gt;
-        &lt;WINDOWPLACEMENT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-        &lt;length&gt;44&lt;/length&gt;
-        &lt;flags&gt;0&lt;/flags&gt;
-        &lt;showCmd&gt;1&lt;/showCmd&gt;
-        &lt;minPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/minPosition&gt;
-        &lt;maxPosition&gt;
-        &lt;X&gt;-1&lt;/X&gt;
-        &lt;Y&gt;-1&lt;/Y&gt;
-        &lt;/maxPosition&gt;
-        &lt;normalPosition&gt;
-        &lt;Left&gt;10&lt;/Left&gt;
-        &lt;Top&gt;10&lt;/Top&gt;
-        &lt;Right&gt;541&lt;/Right&gt;
-        &lt;Bottom&gt;36&lt;/Bottom&gt;
-        &lt;/normalPosition&gt;
-        &lt;/WINDOWPLACEMENT&gt;
-      </value>
+                <value></value>
             </setting>
             <setting name="PropertyFilterSets" serializeAs="String">
                 <value>


### PR DESCRIPTION
Snoop windows appeared in ackward positions/sizes because the placements had default values from some machine.

This was especially annoying when trying to use the zoomer which had, on first use, only it's titlebar visible.

I also refactored the loading and saving of windowplacements to SnoopWindowUtils.