### PR TITLE
Styles from application resources are sometimes used

### DIFF
--- a/Snoop/DebugListenerTab/DebugListenerControl.xaml
+++ b/Snoop/DebugListenerTab/DebugListenerControl.xaml
@@ -22,35 +22,35 @@
 				<ColumnDefinition Width="Auto"/>
 			</Grid.ColumnDefinitions>
 
-			<CheckBox Name="checkBoxStartListening" Margin="10" Checked="checkBoxStartListening_Checked" Unchecked="checkBoxStartListening_Unchecked">
+			<CheckBox Name="checkBoxStartListening" Style="{x:Null}" Margin="10" Checked="checkBoxStartListening_Checked" Unchecked="checkBoxStartListening_Unchecked">
 				<TextBlock Style="{x:Null}" Text="Start Listening"/>
 			</CheckBox>
 
 			<StackPanel Orientation="Horizontal" Grid.Column="1">
-				<TextBlock Text="WPF Trace Level: " VerticalAlignment="Center" Margin="0,0,10,0"/>
-				<ComboBox Name="comboBoxPresentationTraceLevel" Width="100" Height="25" SelectedIndex="2" SelectionChanged="comboBoxPresentationTraceLevel_SelectionChanged">
-					<ComboBoxItem Tag="Off">
+				<TextBlock Style="{x:Null}" Text="WPF Trace Level: " VerticalAlignment="Center" Margin="0,0,10,0"/>
+				<ComboBox Name="comboBoxPresentationTraceLevel" Style="{x:Null}" Width="100" Height="25" SelectedIndex="2" SelectionChanged="comboBoxPresentationTraceLevel_SelectionChanged">
+					<ComboBoxItem Style="{x:Null}" Tag="Off">
 						<TextBlock Style="{x:Null}" Text="Off"/>
 					</ComboBoxItem>
-					<ComboBoxItem Tag="Critical">
+					<ComboBoxItem Style="{x:Null}" Tag="Critical">
 						<TextBlock Style="{x:Null}" Text="Critical"/>
 					</ComboBoxItem>
-					<ComboBoxItem Tag="Error">
+					<ComboBoxItem Style="{x:Null}" Tag="Error">
 						<TextBlock Style="{x:Null}" Text="Error"/>
 					</ComboBoxItem>
-					<ComboBoxItem Tag="Warning">
+					<ComboBoxItem Style="{x:Null}" Tag="Warning">
 						<TextBlock Style="{x:Null}" Text="Warning"/>
 					</ComboBoxItem>
-					<ComboBoxItem Tag="Information">
+					<ComboBoxItem Style="{x:Null}" Tag="Information">
 						<TextBlock Style="{x:Null}" Text="Information"/>
 					</ComboBoxItem>
-					<ComboBoxItem Tag="Verbose">
+					<ComboBoxItem Style="{x:Null}" Tag="Verbose">
 						<TextBlock Style="{x:Null}" Text="Verbose"/>
 					</ComboBoxItem>
-					<ComboBoxItem Tag="Activity Tracing">
+					<ComboBoxItem Style="{x:Null}" Tag="Activity Tracing">
 						<TextBlock Style="{x:Null}" Text="Activity Tracing"/>
 					</ComboBoxItem>
-					<ComboBoxItem Tag="All">
+					<ComboBoxItem Style="{x:Null}" Tag="All">
 						<TextBlock Style="{x:Null}" Text="All"/>
 					</ComboBoxItem>
 				</ComboBox>
@@ -58,19 +58,19 @@
 
 
 			<StackPanel Orientation="Horizontal" Margin="10,0,10,10" Grid.Row="1" Grid.ColumnSpan="2">
-				<Button Name="buttonClear" Width="75" Height="25" HorizontalAlignment="Left" Click="buttonClear_Click">
+				<Button Name="buttonClear" Style="{x:Null}" Width="75" Height="25" HorizontalAlignment="Left" Click="buttonClear_Click">
 					<TextBlock Style="{x:Null}" Text="Clear Text"/>
 				</Button>
-				<Button Name="buttonClearFilters" Margin="10,0,0,0" Width="75" Height="25" HorizontalAlignment="Left" Click="buttonClearFilters_Click">
+				<Button Name="buttonClearFilters" Style="{x:Null}" Margin="10,0,0,0" Width="75" Height="25" HorizontalAlignment="Left" Click="buttonClearFilters_Click">
 					<TextBlock Style="{x:Null}" Text="Clear Filters"/>
 				</Button>
-				<Button Name="buttonSetFilters" Margin="10,0,0,0" Width="75" Height="25" HorizontalAlignment="Left" Click="buttonSetFilters_Click">
+				<Button Name="buttonSetFilters" Style="{x:Null}" Margin="10,0,0,0" Width="75" Height="25" HorizontalAlignment="Left" Click="buttonSetFilters_Click">
 					<TextBlock Style="{x:Null}" Text="Edit Filter"/>
 				</Button>
-				<TextBlock Name="textBlockStatus" Margin="10,0,0,0" Text="{Binding Path=FilterStatus}"/>
+				<TextBlock Name="textBlockStatus" Style="{x:Null}" Margin="10,0,0,0" Text="{Binding Path=FilterStatus}"/>
 			</StackPanel>
 
 		</Grid>
-		<TextBox Name="textBoxDebugContent" IsReadOnly="True" Grid.Row="1" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
+		<TextBox Name="textBoxDebugContent" Style="{x:Null}" IsReadOnly="True" Grid.Row="1" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.CanContentScroll="True" ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
 	</Grid>
 </UserControl>

--- a/Snoop/DebugListenerTab/SetFiltersWindow.xaml
+++ b/Snoop/DebugListenerTab/SetFiltersWindow.xaml
@@ -18,22 +18,22 @@
 				<RowDefinition Height="Auto"/>
 			</Grid.RowDefinitions>
 			<!--<StackPanel>-->
-			<ListBox Name="listBoxFilters"  ItemsSource="{Binding Path=Filters}" SelectionMode="Extended"  AlternationCount="2">
+			<ListBox Name="listBoxFilters" Style="{x:Null}" ItemsSource="{Binding Path=Filters}" SelectionMode="Extended"  AlternationCount="2">
 				<ListBox.ContextMenu>
-					<ContextMenu>
-						<MenuItem Name="menuItemGroupFilters" Click="menuItemGroupFilters_Click">
+					<ContextMenu Style="{x:Null}">
+						<MenuItem Name="menuItemGroupFilters" Style="{x:Null}" Click="menuItemGroupFilters_Click">
 							<MenuItem.Header>
-								<TextBlock Text="Group Filters"/>
+								<TextBlock Style="{x:Null}" Text="Group Filters"/>
 							</MenuItem.Header>
 						</MenuItem>
-						<MenuItem Name="menuItemClearFilterGroups" Click="menuItemClearFilterGroups_Click">
+						<MenuItem Name="menuItemClearFilterGroups" Style="{x:Null}" Click="menuItemClearFilterGroups_Click">
 							<MenuItem.Header>
-								<TextBlock Text="Clear Filter Groups"/>
+								<TextBlock Style="{x:Null}" Text="Clear Filter Groups"/>
 							</MenuItem.Header>
 						</MenuItem>
-						<MenuItem Name="menuItemSetInverse" Click="menuItemSetInverse_Click">
+						<MenuItem Name="menuItemSetInverse" Style="{x:Null}" Click="menuItemSetInverse_Click">
 							<MenuItem.Header>
-								<TextBlock Text="Set Inverse"/>
+								<TextBlock Style="{x:Null}" Text="Set Inverse"/>
 							</MenuItem.Header>
 						</MenuItem>
 					</ContextMenu>
@@ -50,7 +50,7 @@
 				<ListBox.ItemTemplate>
 					<DataTemplate>
 						<StackPanel Orientation="Horizontal" Margin="0,5,0,5" Name="stackPanelFilter">
-							<TextBlock Text="{Binding Path=IsInverseText}" Margin="0,5,10,5" FontSize="9" VerticalAlignment="Center" Visibility="Visible">
+							<TextBlock Style="{x:Null}" Text="{Binding Path=IsInverseText}" Margin="0,5,10,5" FontSize="9" VerticalAlignment="Center" Visibility="Visible">
 								<!--
 								<TextBlock.Style>
 									<Style TargetType="TextBlock">
@@ -63,22 +63,22 @@
 								</TextBlock.Style>
 								-->
 							</TextBlock>
-							<ComboBox Width="140" Height="23" Name="comboBoxFilterTypes" SelectedIndex="{Binding Path=FilterType, Mode=TwoWay,Converter={x:Static converters:FilterTypeToIntConverter.Default}}">
-								<ComboBoxItem>
+							<ComboBox Style="{x:Null}" Width="140" Height="23" Name="comboBoxFilterTypes" SelectedIndex="{Binding Path=FilterType, Mode=TwoWay,Converter={x:Static converters:FilterTypeToIntConverter.Default}}">
+								<ComboBoxItem Style="{x:Null}">
 									<TextBlock Style="{x:Null}" Text="Starts With"/>
 								</ComboBoxItem>
-								<ComboBoxItem>
+								<ComboBoxItem Style="{x:Null}">
 									<TextBlock Style="{x:Null}" Text="Ends With"/>
 								</ComboBoxItem>
-								<ComboBoxItem>
+								<ComboBoxItem Style="{x:Null}">
 									<TextBlock Style="{x:Null}" Text="Contains"/>
 								</ComboBoxItem>
-								<ComboBoxItem>
+								<ComboBoxItem Style="{x:Null}">
 									<TextBlock Style="{x:Null}" Text="Regular Expression"/>
 								</ComboBoxItem>
 							</ComboBox>
-							<TextBox Name="textBlockFilter" Loaded="textBlockFilter_Loaded" Width="150" Height="23" Margin="10,0,0,0" Text="{Binding Path=Text, Mode=TwoWay}"/>
-							<Button Name="buttonRemoveFilter" Margin="10,0,0,0" Width="14" Height="14"  Click="buttonRemoveFilter_Click">
+							<TextBox Name="textBlockFilter" Style="{x:Null}" Loaded="textBlockFilter_Loaded" Width="150" Height="23" Margin="10,0,0,0" Text="{Binding Path=Text, Mode=TwoWay}"/>
+							<Button Name="buttonRemoveFilter" Style="{x:Null}" Margin="10,0,0,0" Width="14" Height="14"  Click="buttonRemoveFilter_Click">
 								<Grid>
 									<Path
 										Stretch="Fill"
@@ -94,16 +94,16 @@
 									/>
 								</Grid>
 							</Button>
-							<TextBlock Foreground="Black" Text="{Binding Path=GroupId}" Margin="5,3,0,0"/>
+							<TextBlock Style="{x:Null}" Foreground="Black" Text="{Binding Path=GroupId}" Margin="5,3,0,0"/>
 						</StackPanel>
 					</DataTemplate>
 				</ListBox.ItemTemplate>
 			</ListBox>
-			<Button Margin="0,10,0,0" Grid.Row="1" VerticalAlignment="Bottom" Name="buttonAddFilter" Click="buttonAddFilter_Click" Width="110" Height="25" HorizontalAlignment="Left">
+			<Button Style="{x:Null}" Margin="0,10,0,0" Grid.Row="1" VerticalAlignment="Bottom" Name="buttonAddFilter" Click="buttonAddFilter_Click" Width="110" Height="25" HorizontalAlignment="Left">
 				<TextBlock Style="{x:Null}" Text="Add Another Filter"/>
 			</Button>
 		</Grid>
-		<Button Name="buttonSetFilter" Margin="10,0,0,0" Grid.Row="1" HorizontalAlignment="Left" Height="25" Width="110" Click="buttonSetFilter_Click">
+		<Button Name="buttonSetFilter" Style="{x:Null}" Margin="10,0,0,0" Grid.Row="1" HorizontalAlignment="Left" Height="25" Width="110" Click="buttonSetFilter_Click">
 			<TextBlock Style="{x:Null}" Text="Set Filter"/>
 		</Button>
 	</Grid>

--- a/Snoop/EditUserFilters.xaml
+++ b/Snoop/EditUserFilters.xaml
@@ -45,6 +45,7 @@ All other rights reserved.
 		<TextBox
 			Grid.Row="1"
 			Grid.Column="1"
+		    Style="{x:Null}"
 			VerticalAlignment="Center"
 			Text="{Binding Path=SelectedItem.DisplayName, ElementName=filterSetList}"
 		/>
@@ -67,6 +68,7 @@ All other rights reserved.
 
 		<ListBox
 			x:Name="filterSetList"
+		    Style="{x:Null}"
 			Grid.Row="0"
 			Grid.ColumnSpan="2"
 			ItemsSource="{Binding ItemsSource}"
@@ -89,6 +91,7 @@ All other rights reserved.
 			Orientation="Horizontal"
 		>
 			<Button
+			    Style="{x:Null}"
 				Width="75"
 				IsDefault="True"
 				Click="OkHandler"
@@ -96,6 +99,7 @@ All other rights reserved.
 				<TextBlock Style="{x:Null}" Text="OK"/>
 			</Button>
 			<Button
+			    Style="{x:Null}"
 				Width="75"
 				Margin="5,0,0,0"
 				IsCancel="True"
@@ -113,26 +117,29 @@ All other rights reserved.
 		>
 			<Button
 				x:Name="MoveUp"
+			    Style="{x:Null}"
 				Width="20"
 				Height="20"
 				Click="UpHandler"
 			>
-				<Image Source="{StaticResource scopeUpDrawingImage}" Margin="3"/>
+				<Image Style="{x:Null}" Source="{StaticResource scopeUpDrawingImage}" Margin="3"/>
 			</Button>
 			<Button
 				x:Name="MoveDown"
+			    Style="{x:Null}"
 				Width="20"
 				Height="20"
 				Margin="0,5,0,0"
 				Click="DownHandler"
 			>
-				<Image Source="{StaticResource scopeUpDrawingImage}" Margin="3" RenderTransformOrigin="0.5,0.5">
+				<Image Style="{x:Null}" Source="{StaticResource scopeUpDrawingImage}" Margin="3" RenderTransformOrigin="0.5,0.5">
 					<Image.RenderTransform>
 						<RotateTransform Angle="180"/>
 					</Image.RenderTransform>
 				</Image>
 			</Button>
 			<Button
+			    Style="{x:Null}"
 				Width="50"
 				Margin="0,10,0,0"
 				Click="AddHandler"
@@ -141,6 +148,7 @@ All other rights reserved.
 			</Button>
 			<Button
 				x:Name="DeleteItem"
+			    Style="{x:Null}"
 				Width="50"
 				Margin="0,5,0,0"
 				Click="DeleteHandler"

--- a/Snoop/ErrorDialog.xaml
+++ b/Snoop/ErrorDialog.xaml
@@ -63,6 +63,7 @@ All other rights reserved.
 		<StackPanel Grid.Row="4" HorizontalAlignment="Center" Margin="0,10,0,0" Orientation="Horizontal">
 			<Button
 				x:Name="_buttonCopyToClipboard"
+			    Style="{x:Null}"
 				Width="175"
 				Height="32"
 				Margin="0,0,15,0"
@@ -71,14 +72,14 @@ All other rights reserved.
 				<TextBlock Style="{x:Null}" Text="Copy Exception to Clipboard"/>
 			</Button>
 			<StackPanel Orientation="Vertical" Grid.Row="3">
-				<TextBlock>
-					<Hyperlink NavigateUri="http://snoopwpf.codeplex.com/WorkItem/Create?ProjectName=snoopwpf" RequestNavigate="Hyperlink_RequestNavigate">
+				<TextBlock Style="{x:Null}">
+					<Hyperlink Style="{x:Null}" NavigateUri="http://snoopwpf.codeplex.com/WorkItem/Create?ProjectName=snoopwpf" RequestNavigate="Hyperlink_RequestNavigate">
 						<TextBlock Style="{x:Null}" Text="Click Here to create an issue on CodePlex."/>
 					</Hyperlink>
 				</TextBlock>
 
-				<TextBlock>
-					<Hyperlink NavigateUri="https://github.com/cplotts/snoopwpf/issues/new" RequestNavigate="Hyperlink_RequestNavigate">
+				<TextBlock Style="{x:Null}">
+					<Hyperlink Style="{x:Null}" NavigateUri="https://github.com/cplotts/snoopwpf/issues/new" RequestNavigate="Hyperlink_RequestNavigate">
 						<TextBlock Style="{x:Null}" Text="Click Here to create an issue on GitHub."/>
 					</Hyperlink>
 				</TextBlock>
@@ -88,6 +89,7 @@ All other rights reserved.
 		<StackPanel Grid.Row="5" HorizontalAlignment="Center" Margin="0,40,0,0" Orientation="Horizontal">
 			<CheckBox
 				x:Name="_checkBoxRemember"
+			    Style="{x:Null}"
 				Grid.Row="5"
 				VerticalAlignment="Center"
 				Margin="0,0,10,0"
@@ -101,15 +103,16 @@ All other rights reserved.
 						TextWrapping="Wrap"
 					>
 						<TextBlock.Inlines>
-							<Run Text="This checkbox will remember whether you want to mark the exception handled or not, in the case that there are many unhandled exceptions, so that the dialog does not keep coming up."/>
-							<LineBreak/>
-							<LineBreak/>
-							<Run Text="Note that clicking this checkbox and choosing one of the close buttons, also, in essence, stops this dialog from ever coming up again ... even in the case of a different unhandled exception ... until you Snoop the application all over again."/>
+							<Run Style="{x:Null}" Text="This checkbox will remember whether you want to mark the exception handled or not, in the case that there are many unhandled exceptions, so that the dialog does not keep coming up."/>
+							<LineBreak Style="{x:Null}" />
+							<LineBreak Style="{x:Null}" />
+							<Run Style="{x:Null}" Text="Note that clicking this checkbox and choosing one of the close buttons, also, in essence, stops this dialog from ever coming up again ... even in the case of a different unhandled exception ... until you Snoop the application all over again."/>
 						</TextBlock.Inlines>
 					</TextBlock>
 				</CheckBox.ToolTip>
 			</CheckBox>
 			<Button
+			    Style="{x:Null}"
 				Width="200"
 				Height="32"
 				Margin="0,0,10,0"
@@ -126,6 +129,7 @@ All other rights reserved.
 				</Button.ToolTip>
 			</Button>
 			<Button
+			    Style="{x:Null}"
 				Width="200"
 				Height="32"
 				Click="CloseAndMarkHandled_Click"

--- a/Snoop/EventsView.xaml
+++ b/Snoop/EventsView.xaml
@@ -40,7 +40,7 @@ All other rights reserved.
 			</DataTemplate>
 
 			<DataTemplate DataType="{x:Type my:EventTracker}">
-				<CheckBox IsChecked="{Binding IsEnabled}">
+				<CheckBox Style="{x:Null}" IsChecked="{Binding IsEnabled}">
 					<TextBlock Style="{x:Null}" Text="{Binding RoutedEvent.Name}"/>
 				</CheckBox>
 			</DataTemplate>
@@ -56,12 +56,13 @@ All other rights reserved.
 						<RowDefinition Height="*"/>
 					</Grid.RowDefinitions>
 					<StackPanel Orientation="Horizontal">
-						<ContentControl Content="{Binding EventArgs}" Focusable="False"/>
+						<ContentControl Style="{x:Null}" Content="{Binding EventArgs}" Focusable="False"/>
 						<TextBlock Style="{x:Null}" Text=" on "/>
 						<TextBlock Style="{x:Null}" Text="{Binding Originator.Handler, Converter={StaticResource NiceNamer}}" Grid.Column="1"/>
 					</StackPanel>
 					<ContentControl
 						x:Name="Handler"
+					    Style="{x:Null}"
 						Grid.Row="1"
 						Grid.ColumnSpan="2"
 						Visibility="Collapsed"
@@ -165,7 +166,7 @@ All other rights reserved.
 																	<GradientStop Offset="0" Color="sc#1, 0.398262918, 0.398262918, 0.398262918"/>
 																</LinearGradientBrush>
 															</Border.BorderBrush>
-															<Canvas x:Name="Canvas" Width="16" Height="16">
+															<Canvas x:Name="Canvas" Style="{x:Null}" Width="16" Height="16">
 																<Path
 																	x:Name="Path"
 																	Width="10.0079642791082"
@@ -207,6 +208,7 @@ All other rights reserved.
 					</Border>
 					<Popup
 						x:Name="PART_Popup"
+					    Style="{x:Null}"
 						IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource Mode=TemplatedParent, AncestorType={x:Null}}}"
 						Focusable="False"
 						Placement="Bottom"
@@ -224,8 +226,9 @@ All other rights reserved.
 								BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"
 								BorderThickness="1,1,1,1"
 							/>
-							<ScrollViewer x:Name="ScrollViewer" Margin="1,1,1,1">
+							<ScrollViewer x:Name="ScrollViewer" Style="{x:Null}" Margin="1,1,1,1">
 								<ItemsControl
+								    Style="{x:Null}"
 									ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource TemplatedParent}}"
 									KeyboardNavigation.DirectionalNavigation="Contained"
 								>
@@ -282,6 +285,7 @@ All other rights reserved.
 
 	<ComboBox
 		x:Name="EventChooser"
+	    Style="{x:Null}"
 		i:ComboBoxSettings.IsSnoopPart="True"
 		HorizontalAlignment="Stretch"
 		VerticalAlignment="Stretch"
@@ -296,6 +300,7 @@ All other rights reserved.
 	</ComboBox>
 
 	<Button
+	    Style="{x:Null}"
 		Width="18"
 		Height="18"
 		HorizontalAlignment="Right"
@@ -323,6 +328,7 @@ All other rights reserved.
 
 	<TreeView
 		x:Name="EventTree"
+	    Style="{x:Null}"
 		SelectedItemChanged="EventTree_SelectedItemChanged"
 		Grid.Row="1"
 		ItemsSource="{Binding ElementName=Events, Path=InterestingEvents}"

--- a/Snoop/MethodsTab/FullTypeSelector.xaml
+++ b/Snoop/MethodsTab/FullTypeSelector.xaml
@@ -14,13 +14,13 @@ All other rights reserved.
       SizeToContent="WidthAndHeight">
 
     <Grid Height="282" Width="587">
-        <ComboBox Height="29" HorizontalAlignment="Left" Margin="16,37,0,0" SelectionChanged="comboBoxAssemblies_SelectionChanged" Name="comboBoxAssemblies" VerticalAlignment="Top" Width="507" />
-        <ComboBox Height="30" HorizontalAlignment="Left" Margin="16,110,0,0" Name="comboBoxTypes" VerticalAlignment="Top" Width="507" />
-        <Label Content="Choose assembly" Height="26" HorizontalAlignment="Left" Margin="20,5,0,0" Name="label1" VerticalAlignment="Top" Width="186" />
-        <Label Content="Choose type" Height="32" HorizontalAlignment="Left" Margin="20,84,0,0" Name="label2" VerticalAlignment="Top" Width="185" />
-        <Button Content="Create instance" Height="31" HorizontalAlignment="Left" Margin="20,231,0,0" Name="buttonCreateInstance" Click="buttonCreateInstance_Click" VerticalAlignment="Top" Width="165" />
-        <Button Content="Cancel" Height="31" HorizontalAlignment="Left" Margin="205,231,0,0" Name="buttonCancel" Click="buttonCancel_Click" VerticalAlignment="Top" Width="159" />
-        <Label Content="Type in a value to convert from a string. Otherwise, leave blank to create default new instance." Height="25" HorizontalAlignment="Left" Margin="12,156,0,0" Name="label3" VerticalAlignment="Top" Width="518" />
-        <TextBox Name="textBoxConvertFrom" Height="25" HorizontalAlignment="Left" Margin="16,187,0,0"  VerticalAlignment="Top" Width="413" />
+        <ComboBox Style="{x:Null}" Height="29" HorizontalAlignment="Left" Margin="16,37,0,0" SelectionChanged="comboBoxAssemblies_SelectionChanged" Name="comboBoxAssemblies" VerticalAlignment="Top" Width="507" />
+        <ComboBox Style="{x:Null}" Height="30" HorizontalAlignment="Left" Margin="16,110,0,0" Name="comboBoxTypes" VerticalAlignment="Top" Width="507" />
+        <Label Style="{x:Null}" Content="Choose assembly" Height="26" HorizontalAlignment="Left" Margin="20,5,0,0" Name="label1" VerticalAlignment="Top" Width="186" />
+        <Label Style="{x:Null}" Content="Choose type" Height="32" HorizontalAlignment="Left" Margin="20,84,0,0" Name="label2" VerticalAlignment="Top" Width="185" />
+        <Button Style="{x:Null}" Content="Create instance" Height="31" HorizontalAlignment="Left" Margin="20,231,0,0" Name="buttonCreateInstance" Click="buttonCreateInstance_Click" VerticalAlignment="Top" Width="165" />
+        <Button Style="{x:Null}" Content="Cancel" Height="31" HorizontalAlignment="Left" Margin="205,231,0,0" Name="buttonCancel" Click="buttonCancel_Click" VerticalAlignment="Top" Width="159" />
+        <Label Style="{x:Null}" Content="Type in a value to convert from a string. Otherwise, leave blank to create default new instance." Height="25" HorizontalAlignment="Left" Margin="12,156,0,0" Name="label3" VerticalAlignment="Top" Width="518" />
+        <TextBox Name="textBoxConvertFrom" Style="{x:Null}" Height="25" HorizontalAlignment="Left" Margin="16,187,0,0"  VerticalAlignment="Top" Width="413" />
     </Grid>
 </Window>

--- a/Snoop/MethodsTab/MethodsControl.xaml
+++ b/Snoop/MethodsTab/MethodsControl.xaml
@@ -34,6 +34,7 @@ All other rights reserved.
 					Text="{Binding ParameterName}"
 				/>
 				<ComboBox
+				    Style="{x:Null}"
 					Grid.Column="1"
 					Width="129"
 					HorizontalAlignment="Left"
@@ -57,6 +58,7 @@ All other rights reserved.
 					Text="{Binding ParameterName}"
 				/>
 				<ComboBox
+				    Style="{x:Null}"
 					Grid.Column="1"
 					Width="129"
 					HorizontalAlignment="Left"
@@ -106,6 +108,7 @@ All other rights reserved.
 					Text="{Binding ParameterName}"
 				/>
 				<Button
+				    Style="{x:Null}"
 					Grid.Column="1"
 					Width="150"
 					Height="25"
@@ -115,6 +118,7 @@ All other rights reserved.
 					<TextBlock Style="{x:Null}" Text="Create/Modify Parameter"/>
 				</Button>
 				<Button
+				    Style="{x:Null}"
 					Grid.Column="2"
 					Width="150"
 					Height="25"
@@ -146,6 +150,7 @@ All other rights reserved.
 
 		<StackPanel Orientation="Horizontal" Grid.Row="0">
 			<Button
+			    Style="{x:Null}"
 				Height="30"
 				Width="100"
 				VerticalAlignment="Center"
@@ -179,6 +184,7 @@ All other rights reserved.
 
 		<CheckBox
 			x:Name="_checkBoxUseDataContext"
+		    Style="{x:Null}"
 			Grid.Row="1"
 		>
 			<TextBlock Style="{x:Null}" Text="Use DataContext Property"/>
@@ -192,7 +198,7 @@ All other rights reserved.
 				FontWeight="Bold"
 				Text="Method:"
 			/>
-			<ComboBox x:Name="comboBoxMethods" Width="350" Height="25"/>
+			<ComboBox x:Name="comboBoxMethods" Style="{x:Null}" Width="350" Height="25"/>
 		</StackPanel>
 
 		<StackPanel
@@ -209,6 +215,7 @@ All other rights reserved.
 			/>
 			<ItemsControl
 				x:Name="itemsControlParameters"
+			    Style="{x:Null}"
 				Grid.Row="1"
 				Margin="0,10,0,0"
 				ItemTemplateSelector="{StaticResource SnoopParameterInformationTemplateSelector}"
@@ -216,6 +223,7 @@ All other rights reserved.
 		</StackPanel>
 
 		<Button
+		    Style="{x:Null}"
 			Grid.Row="4"
 			Width="200"
 			Height="25"

--- a/Snoop/MethodsTab/ParameterCreator.xaml
+++ b/Snoop/MethodsTab/ParameterCreator.xaml
@@ -24,15 +24,15 @@ All other rights reserved.
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <TextBlock Name="TextBlockDescription" x:FieldModifier="public" FontWeight="Bold" Grid.Column="0" HorizontalAlignment="Left" TextWrapping="Wrap" />
+        <TextBlock Name="TextBlockDescription" x:FieldModifier="public" Style="{x:Null}" FontWeight="Bold" Grid.Column="0" HorizontalAlignment="Left" TextWrapping="Wrap" />
         <snoopNS:PropertyInspector x:Name="propertyInspector" Grid.Row="1"
                                  RootTarget="{Binding Path=RootTarget, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:ParameterCreator}}}" 
                                  NameValueOnly="True"
                                  />
 
         <StackPanel Margin="15,15,0,15" Grid.Row="2" Orientation="Horizontal">
-            <Button Name="btnOK" Height="25" Width="100" Grid.Row="1" Margin="0,0,0,0" Click="OKClick" Content="OK" HorizontalAlignment="Left" VerticalAlignment="Center" />
-            <Button Name="btnCancel" Height="25" Width="100" Grid.Row="1" Margin="15,0,0,0" Click="CancelClick" Content="Canel" HorizontalAlignment="Left" VerticalAlignment="Center" />
+            <Button Name="btnOK" Style="{x:Null}" Height="25" Width="100" Grid.Row="1" Margin="0,0,0,0" Click="OKClick" Content="OK" HorizontalAlignment="Left" VerticalAlignment="Center" />
+            <Button Name="btnCancel" Style="{x:Null}" Height="25" Width="100" Grid.Row="1" Margin="15,0,0,0" Click="CancelClick" Content="Canel" HorizontalAlignment="Left" VerticalAlignment="Center" />
         </StackPanel>
         
     </Grid>

--- a/Snoop/MethodsTab/TypeSelector.xaml
+++ b/Snoop/MethodsTab/TypeSelector.xaml
@@ -12,8 +12,8 @@ All other rights reserved.
              mc:Ignorable="d" 
              d:DesignHeight="173" d:DesignWidth="524" SizeToContent="WidthAndHeight">
     <Grid Height="130" Width="495">
-        <ComboBox Height="30" HorizontalAlignment="Left" Margin="29,32,0,0" Name="comboBoxTypes" VerticalAlignment="Top" Width="439" />
-        <Button Content="Create Instance" Height="30" HorizontalAlignment="Left" Margin="29,88,0,0" Name="buttonCreateInstance" Click="buttonCreateInstance_Click" VerticalAlignment="Top" Width="136" />
-        <Button Content="Cancel" Height="30" HorizontalAlignment="Left" Margin="188,88,0,0" Name="buttonCancel" Click="buttonCancel_Click" VerticalAlignment="Top" Width="130" />
+        <ComboBox Style="{x:Null}" Height="30" HorizontalAlignment="Left" Margin="29,32,0,0" Name="comboBoxTypes" VerticalAlignment="Top" Width="439" />
+        <Button Style="{x:Null}" Content="Create Instance" Height="30" HorizontalAlignment="Left" Margin="29,88,0,0" Name="buttonCreateInstance" Click="buttonCreateInstance_Click" VerticalAlignment="Top" Width="136" />
+        <Button Style="{x:Null}" Content="Cancel" Height="30" HorizontalAlignment="Left" Margin="188,88,0,0" Name="buttonCancel" Click="buttonCancel_Click" VerticalAlignment="Top" Width="130" />
     </Grid>
 </Window>

--- a/Snoop/Previewer.xaml
+++ b/Snoop/Previewer.xaml
@@ -55,6 +55,7 @@ All other rights reserved.
 						</Border.BorderBrush>
 						<ContentPresenter
 							x:Name="ContentPresenter"
+						    Style="{x:Null}"
 							Margin="1,1,1,1"
 							Content="{TemplateBinding Content}"
 							ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -146,6 +147,7 @@ All other rights reserved.
 						</Border.BorderBrush>
 						<ContentPresenter
 							x:Name="ContentPresenter"
+						    Style="{x:Null}"
 							Margin="1,1,1,1"
 							Content="{TemplateBinding Content}"
 							ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -237,6 +239,7 @@ All other rights reserved.
 						</Border.BorderBrush>
 						<ContentPresenter
 							x:Name="ContentPresenter"
+						    Style="{x:Null}"
 							Margin="1,1,1,1"
 							Content="{TemplateBinding Content}"
 							ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -299,6 +302,7 @@ All other rights reserved.
 		<my:ZoomerControl x:Name="Zoomer"/>
 
 		<Button
+		    Style="{x:Null}"
 			Width="22"
 			Height="20"
 			HorizontalAlignment="Right"
@@ -307,7 +311,7 @@ All other rights reserved.
 			Template="{DynamicResource ButtonLeft}"
 			Command="{x:Static my:Previewer.MagnifyCommand}"
 		>
-			<Image x:Name="Image" Source="{DynamicResource magnifyingGlassDrawingImage}"/>
+			<Image x:Name="Image" Style="{x:Null}" Source="{DynamicResource magnifyingGlassDrawingImage}"/>
 			<Button.ToolTip>
 				<StackPanel>
 					<TextBlock Style="{x:Null}" Text="Bring up the Magnify window on"/>
@@ -317,6 +321,7 @@ All other rights reserved.
 		</Button>
 
 		<ToggleButton
+		    Style="{x:Null}"
 			Width="22"
 			Height="20"
 			HorizontalAlignment="Right"
@@ -325,7 +330,7 @@ All other rights reserved.
 			Template="{DynamicResource ButtonMiddle}"
 			IsChecked="{Binding IsActive}"
 		>
-			<Image Source="{DynamicResource powerDrawingImage}"/>
+			<Image Style="{x:Null}" Source="{DynamicResource powerDrawingImage}"/>
 			<ToggleButton.ToolTip>
 				<StackPanel>
 					<TextBlock Style="{x:Null}" Text="Enable/disable preview area (i.e. the"/>
@@ -335,6 +340,7 @@ All other rights reserved.
 		</ToggleButton>
 
 		<Button
+		    Style="{x:Null}"
 			Width="22"
 			Height="20"
 			HorizontalAlignment="Right"
@@ -342,7 +348,7 @@ All other rights reserved.
 			Template="{DynamicResource ButtonRight}"
 			Command="{x:Static my:Previewer.ScreenshotCommand}"
 		>
-			<Image Margin="1" Source="{DynamicResource cameraDrawingImage}"/>
+			<Image Style="{x:Null}" Margin="1" Source="{DynamicResource cameraDrawingImage}"/>
 			<Button.ToolTip>
 				<TextBlock Style="{x:Null}" Text="Save the current preview as bitmap."/>
 			</Button.ToolTip>

--- a/Snoop/ProperTreeViewResources.xaml
+++ b/Snoop/ProperTreeViewResources.xaml
@@ -121,6 +121,7 @@ All other rights reserved.
 									ClickMode="Press"
 								/>
 								<ContentPresenter
+								    Style="{x:Null}"
 									DataContext="{x:Null}"
 									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 									Content="{TemplateBinding Header}"
@@ -132,6 +133,7 @@ All other rights reserved.
 						</Border>
 						<ItemsPresenter
 							x:Name="ItemsHost"
+						    Style="{x:Null}"
 							Grid.Row="1"
 							Grid.Column="1"
 							Grid.ColumnSpan="2"

--- a/Snoop/PropertyGrid2.xaml
+++ b/Snoop/PropertyGrid2.xaml
@@ -16,33 +16,33 @@ All other rights reserved.
 >
 	<Grid.Resources>
 		<ResourceDictionary>
-			<ContextMenu x:Key="PropertyMenu">
-				<MenuItem Command="{x:Static my:PropertyInspector.DelveCommand}" CommandParameter="{Binding}">
+			<ContextMenu x:Key="PropertyMenu" Style="{x:Null}">
+				<MenuItem Style="{x:Null}" Command="{x:Static my:PropertyInspector.DelveCommand}" CommandParameter="{Binding}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="Delve"/>
 					</MenuItem.Header>
 				</MenuItem>
-				<MenuItem Command="{x:Static my:PropertyInspector.DelveBindingCommand}" CommandParameter="{Binding}">
+				<MenuItem Style="{x:Null}" Command="{x:Static my:PropertyInspector.DelveBindingCommand}" CommandParameter="{Binding}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="Delve Binding"/>
 					</MenuItem.Header>
 				</MenuItem>
-				<MenuItem Command="{x:Static my:PropertyInspector.DelveBindingExpressionCommand}" CommandParameter="{Binding}">
+				<MenuItem Style="{x:Null}" Command="{x:Static my:PropertyInspector.DelveBindingExpressionCommand}" CommandParameter="{Binding}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="Delve BindingExpression"/>
 					</MenuItem.Header>
 				</MenuItem>
-				<MenuItem Command="{x:Static my:PropertyGrid2.ShowBindingErrorsCommand}" CommandParameter="{Binding}">
+				<MenuItem Style="{x:Null}" Command="{x:Static my:PropertyGrid2.ShowBindingErrorsCommand}" CommandParameter="{Binding}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="Display Binding Errors"/>
 					</MenuItem.Header>
 				</MenuItem>
-				<MenuItem Command="{x:Static my:PropertyGrid2.ClearCommand}" CommandParameter="{Binding}">
+				<MenuItem Style="{x:Null}" Command="{x:Static my:PropertyGrid2.ClearCommand}" CommandParameter="{Binding}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="Clear/Reset"/>
 					</MenuItem.Header>
 				</MenuItem>
-				<MenuItem Command="{x:Static my:PropertyInspector.SnipXamlCommand}" CommandParameter="{Binding}">
+				<MenuItem Style="{x:Null}" Command="{x:Static my:PropertyInspector.SnipXamlCommand}" CommandParameter="{Binding}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="Copy this brush"/>
 					</MenuItem.Header>
@@ -77,7 +77,7 @@ All other rights reserved.
 
 			<ControlTemplate x:Key="BreakpointTemplate" TargetType="{x:Type CheckBox}">
 				<Grid>
-					<Image Name="Icon" Source="{DynamicResource noBreakpointDrawingImage}" Width="12" Height="12"/>
+					<Image Name="Icon" Style="{x:Null}" Source="{DynamicResource noBreakpointDrawingImage}" Width="12" Height="12"/>
 				</Grid>
 				<ControlTemplate.Triggers>
 					<Trigger Property="IsChecked" Value="True">
@@ -188,6 +188,7 @@ All other rights reserved.
 
 	<ListView
 		x:Name="ListView"
+	    Style="{x:Null}"
 		Grid.RowSpan="2"
 		MinHeight="0"
 		MinWidth="0"
@@ -250,7 +251,7 @@ All other rights reserved.
 				<GridViewColumn Width="25">
 					<GridViewColumn.CellTemplate>
 						<DataTemplate>
-							<CheckBox IsChecked="{Binding BreakOnChange}" Template="{StaticResource BreakpointTemplate}">
+							<CheckBox Style="{x:Null}" IsChecked="{Binding BreakOnChange}" Template="{StaticResource BreakpointTemplate}">
 								<CheckBox.ToolTip>
 									<TextBlock Style="{x:Null}" Text="Click here to toggle a debug breakpoint on and off."/>
 								</CheckBox.ToolTip>
@@ -301,7 +302,7 @@ All other rights reserved.
 					</GridViewColumn.Header>
 					<GridViewColumn.CellTemplate>
 						<DataTemplate>
-							<ContentControl x:Name="ContentHost" Content="{Binding}" ContentTemplate="{StaticResource ValueSourceTemplate}"/>
+							<ContentControl x:Name="ContentHost" Style="{x:Null}" Content="{Binding}" ContentTemplate="{StaticResource ValueSourceTemplate}"/>
 						</DataTemplate>
 					</GridViewColumn.CellTemplate>
 				</GridViewColumn>

--- a/Snoop/PropertyInspector.xaml
+++ b/Snoop/PropertyInspector.xaml
@@ -49,6 +49,7 @@ All other rights reserved.
     <Grid Grid.Row="1">
         <TextBox
 			x:Name="PropertiesFilter"
+            Style="{x:Null}"
 			Text="{Binding ElementName=propertyInspector, Path=StringFilter, UpdateSourceTrigger=PropertyChanged}"
 			Margin="0,0,260,2"
 			MinHeight="0"
@@ -60,6 +61,7 @@ All other rights reserved.
         </TextBox>
         <CheckBox Name="checkBoxClearAfterDelve" Content="Clear after delve" HorizontalAlignment="Right" Margin="0,3,150,0" />
         <ToggleButton
+            Style="{x:Null}"
 			IsChecked="{Binding ElementName=propertyInspector, Path=ShowDefaults}"
 			Width="18"
 			Height="18"
@@ -93,7 +95,7 @@ All other rights reserved.
                     </Style.Triggers>
                 </Style>
             </Button.Style>
-            <Image Source="{StaticResource scopeUpDrawingImage}" Margin="3"/>
+            <Image Style="{x:Null}" Source="{StaticResource scopeUpDrawingImage}" Margin="3"/>
             <Button.ToolTip>
                 <StackPanel>
                     <TextBlock Style="{x:Null}" Text="Click this button to pop up 1 level in scope"/>
@@ -102,6 +104,7 @@ All other rights reserved.
             </Button.ToolTip>
         </Button>
         <ComboBox
+            Style="{x:Null}"
 			x:Name="FilterSetCombo"
 			i:ComboBoxSettings.IsSnoopPart="True"
 			Width="100"

--- a/Snoop/ScreenshotDialog.xaml
+++ b/Snoop/ScreenshotDialog.xaml
@@ -79,7 +79,7 @@ All other rights reserved.
 				Style="{StaticResource PhotoFrameStyle}"
 				DataContext="{Binding}"
 			/>
-			<TextBlock Grid.Row="1" TextAlignment="Center">Screenshot To Be Saved</TextBlock>
+			<TextBlock Style="{x:Null}" Grid.Row="1" TextAlignment="Center">Screenshot To Be Saved</TextBlock>
 		</Grid>
 
 		<Grid
@@ -93,6 +93,7 @@ All other rights reserved.
 			>
 				<ComboBox
 					x:Name="dpiBox"
+				    Style="{x:Null}"
 					Grid.Column="1"
 					Width="75"
 					Margin="0,0,5,0"
@@ -119,6 +120,7 @@ All other rights reserved.
 				HorizontalAlignment="Right"
 			>
 				<Button
+				    Style="{x:Null}"
 					Width="75"
 					Margin="0,0,5,5"
 					IsDefault="True"
@@ -127,6 +129,7 @@ All other rights reserved.
 					<TextBlock Style="{x:Null}" Text="Save"/>
 				</Button>
 				<Button
+				    Style="{x:Null}"
 					Width="75"
 					Margin="0,0,5,5"
 					IsCancel="True"

--- a/Snoop/Shell/EmbeddedShellView.xaml
+++ b/Snoop/Shell/EmbeddedShellView.xaml
@@ -24,10 +24,12 @@
 		<StackPanel HorizontalAlignment="Right">
 			<CheckBox
 				x:Name="autoExpandCheckBox"
+			    Style="{x:Null}"
 			>
-				<TextBlock Text="Auto-expand"/>
+				<TextBlock Style="{x:Null}" Text="Auto-expand"/>
 				<CheckBox.ToolTip>
 					<TextBlock
+					    Style="{x:Null}"
 						MaxWidth="300"
 						Text="Automatically expands the selected tree item when changed from the PowerShell provider."
 						TextWrapping="Wrap"
@@ -37,6 +39,7 @@
 		</StackPanel>
 		<TextBox
 			x:Name="outputTextBox"
+		    Style="{x:Null}"
 			Grid.Row="1"
 			AcceptsReturn="True"
 			ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -44,12 +47,13 @@
 		/>
 		<TextBox
 			x:Name="commandTextBox"
+		    Style="{x:Null}"
 			Grid.Row="2"
 		>
 			<TextBox.ToolTip>
 				<StackPanel MaxWidth="300">
-					<TextBlock Text="F5 - Reload Profile"/>
-					<TextBlock Text="F12 - Clear Output"/>
+					<TextBlock Style="{x:Null}" Text="F5 - Reload Profile"/>
+					<TextBlock Style="{x:Null}" Text="F12 - Clear Output"/>
 				</StackPanel>
 			</TextBox.ToolTip>
 		</TextBox>

--- a/Snoop/Simple Styles.xaml
+++ b/Snoop/Simple Styles.xaml
@@ -13,18 +13,18 @@ All other rights reserved.
 	
 	<!-- NormalBrush is used as the Background for SimpleButton, SimpleRepeatButton -->
 	<LinearGradientBrush x:Key="NormalBrush" EndPoint="0,1" StartPoint="0,0">
-		<GradientStop Color="#EEE" Offset="0.0"/>
-		<GradientStop Color="#CCC" Offset="1.0"/>
+		<GradientStop Color="#EEEE" Offset="0.0"/>
+		<GradientStop Color="#CCCC" Offset="1.0"/>
 	</LinearGradientBrush>
 	<LinearGradientBrush x:Key="NormalBorderBrush" EndPoint="0,1" StartPoint="0,0">
-		<GradientStop Color="#CCC" Offset="0.0"/>
-		<GradientStop Color="#444" Offset="1.0"/>
+		<GradientStop Color="#CCCC" Offset="0.0"/>
+		<GradientStop Color="#4444" Offset="1.0"/>
 	</LinearGradientBrush>
 	
 	<!-- LightBrush is used for content areas such as Menu, Tab Control background -->
 	<LinearGradientBrush x:Key="LightBrush" EndPoint="0,1" StartPoint="0,0">
-		<GradientStop Color="#FFF" Offset="0.0"/>
-		<GradientStop Color="#EEE" Offset="1.0"/>
+		<GradientStop Color="#FFFF" Offset="0.0"/>
+		<GradientStop Color="#EEEE" Offset="1.0"/>
 	</LinearGradientBrush>
 	
 	
@@ -39,39 +39,39 @@ All other rights reserved.
 	
 	<!-- PressedBrush is used for Pressed in Button, Radio Button, CheckBox -->
 	<LinearGradientBrush x:Key="PressedBrush" EndPoint="0,1" StartPoint="0,0">
-		<GradientStop Color="#BBB" Offset="0.0"/>
-		<GradientStop Color="#EEE" Offset="0.1"/>
-		<GradientStop Color="#EEE" Offset="0.9"/>
-		<GradientStop Color="#FFF" Offset="1.0"/>
+		<GradientStop Color="#BBBB" Offset="0.0"/>
+		<GradientStop Color="#EEEE" Offset="0.1"/>
+		<GradientStop Color="#EEEE" Offset="0.9"/>
+		<GradientStop Color="#FFFF" Offset="1.0"/>
 	</LinearGradientBrush>
 	<LinearGradientBrush x:Key="PressedBorderBrush" EndPoint="0,1" StartPoint="0,0">
-		<GradientStop Color="#444" Offset="0.0"/>
-		<GradientStop Color="#888" Offset="1.0"/>
+		<GradientStop Color="#4444" Offset="0.0"/>
+		<GradientStop Color="#8888" Offset="1.0"/>
 	</LinearGradientBrush>
 
 	<!-- SelectedBackgroundBrush is used for the Selected item in ListBoxItem, ComboBoxItem-->
-	<SolidColorBrush x:Key="SelectedBackgroundBrush" Color="#DDD"/>	
+	<SolidColorBrush x:Key="SelectedBackgroundBrush" Color="#DDDD"/>	
 
 	<!-- Disabled Brushes are used for the Disabled look of each control -->
-	<SolidColorBrush x:Key="DisabledForegroundBrush" Color="#888"/>
-	<SolidColorBrush x:Key="DisabledBackgroundBrush" Color="#EEE"/>
-	<SolidColorBrush x:Key="DisabledBorderBrush" Color="#AAA"/>
+	<SolidColorBrush x:Key="DisabledForegroundBrush" Color="#8888"/>
+	<SolidColorBrush x:Key="DisabledBackgroundBrush" Color="#EEEE"/>
+	<SolidColorBrush x:Key="DisabledBorderBrush" Color="#AAAA"/>
 
 	<!-- Used for background of ScrollViewer, TreeView, ListBox, Expander, TextBox, Tab Control -->
-	<SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FFF"/>
+	<SolidColorBrush x:Key="WindowBackgroundBrush" Color="#FFFF"/>
 	
 	<!-- DefaultedBorderBrush is used to show KeyBoardFocus -->
 	<LinearGradientBrush x:Key="DefaultedBorderBrush" EndPoint="0,1" StartPoint="0,0">
-		<GradientStop Color="#777" Offset="0.0"/>
-		<GradientStop Color="#000" Offset="1.0"/>
+		<GradientStop Color="#7777" Offset="0.0"/>
+		<GradientStop Color="#0000" Offset="1.0"/>
 	</LinearGradientBrush>
 
-	<SolidColorBrush x:Key="SolidBorderBrush" Color="#888"/>
-	<SolidColorBrush x:Key="LightBorderBrush" Color="#AAA"/>
-	<SolidColorBrush x:Key="LightColorBrush" Color="#DDD"/>
+	<SolidColorBrush x:Key="SolidBorderBrush" Color="#8888"/>
+	<SolidColorBrush x:Key="LightBorderBrush" Color="#AAAA"/>
+	<SolidColorBrush x:Key="LightColorBrush" Color="#DDDD"/>
 	
 	<!-- Used for Checkmark, Radio button, TreeViewItem, Expander ToggleButton glyphs -->
-	<SolidColorBrush x:Key="GlyphBrush" Color="#444"/>
+	<SolidColorBrush x:Key="GlyphBrush" Color="#4444"/>
 	
 	
 	<!-- SimpleButtonFocusVisual is used to show keyboard focus around a SimpleButton control -->

--- a/Snoop/SnoopUI.xaml
+++ b/Snoop/SnoopUI.xaml
@@ -24,6 +24,7 @@ All other rights reserved.
 	ShowInTaskbar="True"
 	SnapsToDevicePixels="True"
 	Focusable="False"
+    Style="{x:Null}"
 	DataContext="{Binding RelativeSource={RelativeSource Self}}"
 >
 	<Window.Resources>
@@ -124,6 +125,7 @@ All other rights reserved.
 		<!-- Filter Combo Box -->
 		<ComboBox
 			x:Name="filterComboBox"
+            Style="{x:Null}"
 			i:ComboBoxSettings.IsSnoopPart="True"
 			IsEditable="True"
 			Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"
@@ -217,6 +219,7 @@ All other rights reserved.
 		<!-- Vertical GridSplitter (between the visual tree tree view and the tab control (with the property grid/events view)) -->
 		<GridSplitter
 			x:Name="GridSplitter"
+		    Style="{x:Null}"
 			Grid.Row="0"
 			Grid.RowSpan="3"
 			Grid.Column="1"
@@ -229,11 +232,12 @@ All other rights reserved.
 
 		<!-- Tab Control (for the property grid, the data context property grid, and the events view) -->
 		<TabControl
+		    Style="{x:Null}"
 			Grid.Column="1"
 			Grid.RowSpan="2"
 			Margin="2,2,2,0"
 		>
-			<TabItem>
+			<TabItem Style="{x:Null}">
 				<TabItem.Header>
 					<TextBlock Style="{x:Null}" Text="Properties">
 						<TextBlock.ToolTip>
@@ -250,7 +254,7 @@ All other rights reserved.
 				</TabItem.Header>
 				<local:PropertyInspector x:Name="PropertyGrid" RootTarget="{Binding CurrentSelection.Target}"/>
 			</TabItem>
-			<TabItem>
+			<TabItem Style="{x:Null}">
 				<TabItem.Header>
 					<TextBlock Style="{x:Null}" Text="Data Context">
 						<TextBlock.ToolTip>
@@ -267,7 +271,7 @@ All other rights reserved.
 				</TabItem.Header>
 				<local:PropertyInspector x:Name="DataContextPropertyGrid" RootTarget="{Binding CurrentSelection.Target.DataContext}"/>
 			</TabItem>
-			<TabItem>
+			<TabItem Style="{x:Null}">
 				<TabItem.Header>
 					<TextBlock Style="{x:Null}" Text="Events">
 						<TextBlock.ToolTip>
@@ -284,7 +288,7 @@ All other rights reserved.
 				</TabItem.Header>
 				<local:EventsView/>
 			</TabItem>
-		    <TabItem>
+		    <TabItem Style="{x:Null}">
 		        <TabItem.Header>
 		            <TextBlock Style="{x:Null}" Text="Triggers">
 		                <TextBlock.ToolTip>
@@ -303,7 +307,7 @@ All other rights reserved.
 		                                  IsSelected="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type TabItem}}}" />
 		    </TabItem>
 
-			<TabItem>
+			<TabItem Style="{x:Null}">
 				<TabItem.Header>
 					<TextBlock Style="{x:Null}" Text="Methods">
 						<TextBlock.ToolTip>
@@ -327,6 +331,7 @@ All other rights reserved.
 
 			<TabItem
 				x:Name="PowerShellTab"
+			    Style="{x:Null}"
 				Visibility="{Binding Converter={StaticResource isPowerShellInstalled}}"
 			>
 				<TabItem.Header>
@@ -344,7 +349,7 @@ All other rights reserved.
 					</TextBlock>
 				</TabItem.Header>
 			</TabItem>
-			<TabItem>
+			<TabItem Style="{x:Null}">
 				<TabItem.Header>
 					<TextBlock Style="{x:Null}" Text="Debug Listener">
 						<TextBlock.ToolTip>
@@ -366,6 +371,7 @@ All other rights reserved.
 
 		<!-- Horizontal GridSplitter (between the tab control (with the property grid/events view) and the previewer) -->
 		<GridSplitter
+		    Style="{x:Null}"
 			Grid.Row="2"
 			Grid.Column="1"
 			Height="4"
@@ -384,11 +390,11 @@ All other rights reserved.
 		/>
 
 		<!-- StatusBar -->
-		<StatusBar Grid.Row="3" Grid.ColumnSpan="4">
+		<StatusBar Style="{x:Null}" Grid.Row="3" Grid.ColumnSpan="2" Grid.Column="0">
 			<StackPanel Orientation="Horizontal">
 				<StackPanel Orientation="Horizontal">
-					<TextBlock Text="Keyboard.FocusedElement:"/>
-					<TextBlock Margin="3,0,0,0">
+					<TextBlock Style="{x:Null}" Text="Keyboard.FocusedElement:"/>
+					<TextBlock Style="{x:Null}" Margin="3,0,0,0">
 						<local:NoFocusHyperlink
 							Focusable="False"
 							Command="{x:Static local:SnoopUI.SelectFocusCommand}"
@@ -397,18 +403,18 @@ All other rights reserved.
 							<TextBlock Text="{Binding CurrentFocus, Converter={StaticResource niceNamer}}"/>
 						</local:NoFocusHyperlink>
 					</TextBlock>
-					<TextBlock Text="; "/>
+					<TextBlock Style="{x:Null}" Text="; "/>
 					<StackPanel.ToolTip>
 						<StackPanel>
-							<TextBlock Text="This is the object that has keyboard focus."/>
-							<TextBlock Text="Click the link to select this object."/>
+							<TextBlock Style="{x:Null}" Text="This is the object that has keyboard focus."/>
+							<TextBlock Style="{x:Null}" Text="Click the link to select this object."/>
 						</StackPanel>
 					</StackPanel.ToolTip>
 				</StackPanel>
 
 				<StackPanel Orientation="Horizontal">
-					<TextBlock Text="Current FocusScope:"/>
-					<TextBlock Margin="3,0,0,0">
+					<TextBlock Style="{x:Null}" Text="Current FocusScope:"/>
+					<TextBlock Style="{x:Null}" Margin="3,0,0,0">
 						<local:NoFocusHyperlink
 							Focusable="False"
 							Command="{x:Static local:SnoopUI.SelectFocusScopeCommand}"
@@ -419,8 +425,8 @@ All other rights reserved.
 					</TextBlock>
 					<StackPanel.ToolTip>
 						<StackPanel>
-							<TextBlock Text="This is the object that is the root of the current focus scope."/>
-							<TextBlock Text="Click the link to select this object."/>
+							<TextBlock Style="{x:Null}" Text="This is the object that is the root of the current focus scope."/>
+							<TextBlock Style="{x:Null}" Text="Click the link to select this object."/>
 						</StackPanel>
 					</StackPanel.ToolTip>
 				</StackPanel>

--- a/Snoop/TriggersTab/TriggersView.xaml
+++ b/Snoop/TriggersTab/TriggersView.xaml
@@ -28,14 +28,17 @@
                                     BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" Margin="2">
                                 <Grid>
                                     <Border Background="#0F000000" Height="18" VerticalAlignment="Top" />
-                                    <ContentPresenter TextBlock.FontWeight="Bold" TextBlock.FontSize="11"
+                                    <ContentPresenter Style="{x:Null}"
+                                                      TextBlock.FontWeight="Bold" TextBlock.FontSize="11"
                                                       TextBlock.Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" 
                                                       Content="{TemplateBinding Header}"
                                                       VerticalAlignment="Top" Margin="20,0,0,0" />
-                                    <Image x:Name="icon" Source="/Snoop;component/Resources/triggeritem.png"
+                                    <Image x:Name="icon" 
+                                           Style="{x:Null}"
+                                           Source="/Snoop;component/Resources/triggeritem.png"
                                            Margin="4,2,0,0"
                                            VerticalAlignment="Top" HorizontalAlignment="Left" Width="12" Height="12" />
-                                    <ContentPresenter Content="{TemplateBinding Content}" Margin="4,16,4,4" />
+                                    <ContentPresenter Style="{x:Null}" Content="{TemplateBinding Content}" Margin="4,16,4,4" />
                                 </Grid>
                             </Border>
                         </ControlTemplate>
@@ -51,7 +54,7 @@
                         BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="true"
                         Padding="1">
-                    <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    <ItemsPresenter Style="{x:Null}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                 </Border>
                 <ControlTemplate.Triggers>
                     <Trigger Property="IsEnabled"
@@ -192,7 +195,7 @@
                     </Grid.ColumnDefinitions>
 
                     <TextBlock x:Name="key" Grid.Column="0" Style="{x:Null}" Text="{Binding Value.DisplayName, Mode=OneWay}" Background="Transparent" />
-                    <ContentPresenter x:Name="value" Grid.Column="1" Margin="4,0,0,0" Content="{Binding Value}" ContentTemplateSelector="{StaticResource EditorSelector}" />
+                    <ContentPresenter x:Name="value" Style="{x:Null}" Grid.Column="1" Margin="4,0,0,0" Content="{Binding Value}" ContentTemplateSelector="{StaticResource EditorSelector}" />
                 </Grid>
 
                 <DataTemplate.Triggers>
@@ -233,9 +236,13 @@
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate DataType="{x:Type triggers:ConditionItem}">
                                     <StackPanel Orientation="Horizontal">
-                                        <Image x:Name="image" Source="/Snoop;component/Resources/inactive.png"
+                                        <Image x:Name="image" 
+                                               Style="{x:Null}"
+                                               Source="/Snoop;component/Resources/inactive.png"
                                                Height="16" Width="16" />
-                                        <TextBlock x:Name="conditionText" Text="{Binding Condition}" />
+                                        <TextBlock x:Name="conditionText" 
+                                                   Style="{x:Null}"
+                                                   Text="{Binding Condition}" />
                                     </StackPanel>
                                     <DataTemplate.Triggers>
                                         <DataTrigger Binding="{Binding IsActive}" Value="True">
@@ -292,8 +299,8 @@
             <!--<RowDefinition Height="1*"/>-->
         </Grid.RowDefinitions>
 
-        <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Disabled">
-            <ItemsControl ItemsSource="{Binding TriggerItems, ElementName=triggerView}">
+        <ScrollViewer Style="{x:Null}" Grid.Row="0" HorizontalScrollBarVisibility="Disabled">
+            <ItemsControl Style="{x:Null}" ItemsSource="{Binding TriggerItems, ElementName=triggerView}">
                 <ItemsControl.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.ContainerStyle>
@@ -303,7 +310,8 @@
                                     <Setter.Value>
                                         <ControlTemplate TargetType="{x:Type GroupItem}">
                                             <StackPanel Margin="8">
-                                                <TextBlock Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                                                <TextBlock Style="{x:Null}"
+                                                           Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                                            VerticalAlignment="Center"
                                                            FontWeight="Bold"
                                                            Text="{Binding Path=Name}" />
@@ -331,7 +339,8 @@
         </Grid>-->
     </Grid>
 
-    <TextBlock HorizontalAlignment="Center"
+    <TextBlock Style="{x:Null}"
+               HorizontalAlignment="Center"
                VerticalAlignment="Center"
                Text="The element has no triggers"
                Visibility="{Binding HasTriggerItems, ElementName=triggerView, Converter={x:Static converters:BoolToVisibilityConverter.DefaultInstance}}"

--- a/Snoop/ValueEditors/EditorTemplates.xaml
+++ b/Snoop/ValueEditors/EditorTemplates.xaml
@@ -23,7 +23,7 @@ All other rights reserved.
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type my:StandardValueEditor}">
-					<ContentPresenter Name="ValueHolder" ContentTemplate="{StaticResource UnselectedValueTemplate}" Content="{Binding RelativeSource={RelativeSource TemplatedParent}}">
+					<ContentPresenter Name="ValueHolder" Style="{x:Null}" ContentTemplate="{StaticResource UnselectedValueTemplate}" Content="{Binding RelativeSource={RelativeSource TemplatedParent}}">
 						<ContentPresenter.ToolTip>
 							<TextBlock Style="{x:Null}" Text="{TemplateBinding DescriptiveValue}"/>
 						</ContentPresenter.ToolTip>
@@ -55,11 +55,13 @@ All other rights reserved.
 					<StackPanel Orientation="Horizontal">
 						<CheckBox
 							x:Name="PART_CheckBox"
+						    Style="{x:Null}"
 							IsChecked="{Binding Value, Mode=TwoWay}"
 							IsEnabled="{TemplateBinding IsEditable}"
 							VerticalAlignment="Center"
 						/>
-						<TextBlock Margin="3,0" 
+						<TextBlock Style="{x:Null}" 
+						           Margin="3,0" 
 											 Text="{Binding Path=DescriptiveValue}"
 											 Visibility="{Binding Path=IsExpression, Converter={StaticResource BooleanToVisibilityConverter}}"
 											 VerticalAlignment="Center"
@@ -84,8 +86,8 @@ All other rights reserved.
 			<DataTemplate x:Key="UnselectedValueTemplate">
 				<Grid Height="16" HorizontalAlignment="Left">
                     <Grid.ToolTip>
-                        <ToolTip>
-                            <ListBox ItemsSource="{Binding Value, Converter={x:Static converters:BrushStopsConverter.DefaultInstance}}" 
+                        <ToolTip Style="{x:Null}">
+                            <ListBox Style="{x:Null}" ItemsSource="{Binding Value, Converter={x:Static converters:BrushStopsConverter.DefaultInstance}}" 
                                         Height="200"
                                         Width="200">
                                 <ItemsControl.ItemTemplate>
@@ -96,11 +98,13 @@ All other rights reserved.
                                                 <ColumnDefinition Width="Auto" />
                                                 <ColumnDefinition Width="40" />
                                             </Grid.ColumnDefinitions>
-                                            <TextBlock Grid.Column="0" 
+                                            <TextBlock Style="{x:Null}"
+                                                       Grid.Column="0" 
                                                        Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                                        Text="{Binding Offset}" 
                                                        Margin="4" />
-                                            <TextBlock Grid.Column="1" 
+                                            <TextBlock Style="{x:Null}"
+                                                       Grid.Column="1" 
                                                        Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                                        Text="{Binding ColorText}" 
                                                        Margin="4" />
@@ -139,7 +143,7 @@ All other rights reserved.
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type my:BrushValueEditor}">
-					<ContentPresenter Name="ValueHolder" ContentTemplate="{StaticResource UnselectedValueTemplate}" Content="{Binding RelativeSource={RelativeSource TemplatedParent}}"/>
+					<ContentPresenter Name="ValueHolder" Style="{x:Null}" ContentTemplate="{StaticResource UnselectedValueTemplate}" Content="{Binding RelativeSource={RelativeSource TemplatedParent}}"/>
 
 					<ControlTemplate.Triggers>
 						<DataTrigger Binding="{Binding Value}" Value="{x:Null}">
@@ -166,14 +170,14 @@ All other rights reserved.
 			</DataTemplate>
 
 			<DataTemplate x:Key="SelectedValueTemplate">
-				<ComboBox Height="16" Padding="2,-2,2,0" ItemsSource="{Binding Values}" IsSynchronizedWithCurrentItem="True"/>
+				<ComboBox Style="{x:Null}" Height="16" Padding="2,-2,2,0" ItemsSource="{Binding Values}" IsSynchronizedWithCurrentItem="True"/>
 			</DataTemplate>
 		</Style.Resources>
 
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type my:EnumValueEditor}">
-					<ContentPresenter Name="ValueHolder" ContentTemplate="{StaticResource UnselectedValueTemplate}" Content="{Binding RelativeSource={RelativeSource TemplatedParent}}"/>
+					<ContentPresenter Name="ValueHolder" Style="{x:Null}" ContentTemplate="{StaticResource UnselectedValueTemplate}" Content="{Binding RelativeSource={RelativeSource TemplatedParent}}"/>
 
 					<ControlTemplate.Triggers>
 						<MultiTrigger>

--- a/Snoop/Zoomer.xaml
+++ b/Snoop/Zoomer.xaml
@@ -33,19 +33,19 @@ All other rights reserved.
 		</Grid.Background>
 
 		<Grid.ContextMenu>
-			<ContextMenu>
-				<MenuItem Command="{x:Static xv:Zoomer.SwitchTo2DCommand}">
+			<ContextMenu Style="{x:Null}">
+				<MenuItem Style="{x:Null}" Command="{x:Static xv:Zoomer.SwitchTo2DCommand}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="2D view"/>
 					</MenuItem.Header>
 				</MenuItem>
-				<MenuItem Command="{x:Static xv:Zoomer.SwitchTo3DCommand}">
+				<MenuItem Style="{x:Null}" Command="{x:Static xv:Zoomer.SwitchTo3DCommand}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="3D view"/>
 					</MenuItem.Header>
 				</MenuItem>
 				<Separator/>
-				<MenuItem Command="{x:Static xv:Zoomer.ResetCommand}">
+				<MenuItem Style="{x:Null}" Command="{x:Static xv:Zoomer.ResetCommand}">
 					<MenuItem.Header>
 						<TextBlock Style="{x:Null}" Text="Reset"/>
 					</MenuItem.Header>
@@ -53,7 +53,7 @@ All other rights reserved.
 			</ContextMenu>
 		</Grid.ContextMenu>
 
-		<Viewbox x:Name="Viewbox"/>
+		<Viewbox x:Name="Viewbox" Style="{x:Null}" />
 
 		<StackPanel
 			Orientation="Horizontal"
@@ -94,6 +94,7 @@ All other rights reserved.
 
 		<Slider
 			x:Name="ColorSlider"
+		    Style="{x:Null}"
 			Width="100"
 			HorizontalAlignment="Right"
 			VerticalAlignment="Top"
@@ -112,6 +113,7 @@ All other rights reserved.
 
 		<Slider
 			x:Name="ZScaleSlider"
+		    Style="{x:Null}"
 			Width="100"
 			HorizontalAlignment="Right"
 			VerticalAlignment="Bottom"

--- a/Snoop/ZoomerControl.xaml
+++ b/Snoop/ZoomerControl.xaml
@@ -32,10 +32,11 @@ All other rights reserved.
 			</Binding>
 		</Grid.Background>
 
-		<Viewbox x:Name="Viewbox"/>
+		<Viewbox x:Name="Viewbox" Style="{x:Null}" />
 
 		<Slider
 			x:Name="ColorSlider"
+		    Style="{x:Null}"
 			Width="100"
 			HorizontalAlignment="Right"
 			VerticalAlignment="Top"


### PR DESCRIPTION
This PR sets all styles to x:Null where we don't provide own styles.

This should fix #60.