### PR TITLE
Prevent window from being restored on screen that's disconnected/off

### DIFF
--- a/Snoop/Snoop.csproj
+++ b/Snoop/Snoop.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />

--- a/Snoop/SnoopWindowUtils.cs
+++ b/Snoop/SnoopWindowUtils.cs
@@ -1,4 +1,4 @@
-﻿// (c) Copyright Cory Plotts.
+// (c) Copyright Cory Plotts.
 // This source is subject to the Microsoft Public License (Ms-PL).
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved.
@@ -11,6 +11,7 @@ namespace Snoop
 {
     using System.Runtime.InteropServices;
     using System.Windows.Interop;
+    using Rectangle = System.Drawing.Rectangle;
 
     public static class SnoopWindowUtils
 	{
@@ -88,7 +89,8 @@ namespace Snoop
 
 	    public static void LoadWindowPlacement(Window window, WINDOWPLACEMENT? windowPlacement)
 	    {
-	        if (windowPlacement.HasValue == false)
+	        if (windowPlacement.HasValue == false
+	            || IsVisibleOnAnyScreen(windowPlacement.Value.normalPosition))
 	        {
 	            return;
 	        }
@@ -115,6 +117,21 @@ namespace Snoop
 	        Win32.GetWindowPlacement(hwnd, out windowPlacement);
 
 	        saveAction(windowPlacement);
+	    }
+
+	    private static bool IsVisibleOnAnyScreen(RECT rect)
+	    {
+	        var rectangle = new Rectangle(rect.Left, rect.Top, rect.Width, rect.Height);
+
+	        foreach (var screen in System.Windows.Forms.Screen.AllScreens)
+	        {
+	            if (screen.WorkingArea.IntersectsWith(rectangle))
+	            {
+	                return true;
+	            }
+	        }
+
+	        return false;
 	    }
 	}
 }

--- a/Snoop/SnoopWindowUtils.cs
+++ b/Snoop/SnoopWindowUtils.cs
@@ -90,7 +90,7 @@ namespace Snoop
 	    public static void LoadWindowPlacement(Window window, WINDOWPLACEMENT? windowPlacement)
 	    {
 	        if (windowPlacement.HasValue == false
-	            || IsVisibleOnAnyScreen(windowPlacement.Value.normalPosition))
+	            || IsVisibleOnAnyScreen(windowPlacement.Value.normalPosition) == false)
 	        {
 	            return;
 	        }

--- a/Snoop/WindowPlacement.cs
+++ b/Snoop/WindowPlacement.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Snoop
 {
-	// AK: TODO: Move this to NativeMethods.cs
+    // AK: TODO: Move this to NativeMethods.cs
 
 	// RECT structure required by WINDOWPLACEMENT structure
 	[Serializable]
@@ -27,6 +27,10 @@ namespace Snoop
 			this.Right = right;
 			this.Bottom = bottom;
 		}
+
+	    public int Width => this.Right - this.Left;
+
+	    public int Height => this.Bottom - this.Top;
 	}
 
 	// POINT structure required by WINDOWPLACEMENT structure


### PR DESCRIPTION
This PR adds code that will prevent windows from being restored on a screen that's disconnected/off when loading saved window placements.