### PR TITLE
Increasing version from 2.10 to 2.11

### DIFF
--- a/ManagedInjectorLauncher/Properties/AssemblyInfo.cs
+++ b/ManagedInjectorLauncher/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.10.0.0")]
-[assembly: AssemblyFileVersion("2.10.0.0")]
+[assembly: AssemblyVersion("2.11.0.0")]
+[assembly: AssemblyFileVersion("2.11.0.0")]

--- a/Snoop/Properties/AssemblyInfo.cs
+++ b/Snoop/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.10.0.0")]
-[assembly: AssemblyFileVersion("2.10.0.0")]
+[assembly: AssemblyVersion("2.11.0.0")]
+[assembly: AssemblyFileVersion("2.11.0.0")]


### PR DESCRIPTION
We forgot to increase the version number after releasing version 2.10.
This PR just increases the version from 2.10 to 2.11.
In the future we should tag a released version and increase the version in master immediately afterwards. Otherwise people might get confused about which version is in master.