### PR TITLE
Fix for #111

### DIFF
--- a/ManagedInjectorLauncher/Properties/AssemblyInfo.cs
+++ b/ManagedInjectorLauncher/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.10.0.0")]
-[assembly: AssemblyFileVersion("2.10.0.0")]
+[assembly: AssemblyVersion("2.11.0.0")]
+[assembly: AssemblyFileVersion("2.11.0.0")]

--- a/Snoop/Infrastructure/ResourceDictionaryKeyHelpers.cs
+++ b/Snoop/Infrastructure/ResourceDictionaryKeyHelpers.cs
@@ -3,10 +3,6 @@
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Media;
 
@@ -14,45 +10,45 @@ namespace Snoop.Infrastructure
 {
 	public static class ResourceDictionaryKeyHelpers
 	{
-		public static string GetKeyOfResourceItem(DependencyObject dependencyObject, DependencyProperty dp)
+		public static string GetKeyOfResourceItem(DependencyObject dependencyObject, object resourceItem)
 		{
-			if (dependencyObject == null || dp == null)
+			if (dependencyObject is null
+			    || resourceItem is null)
 			{
 				return string.Empty;
 			}
 
-			object resourceItem = dependencyObject.GetValue(dp);
-			if (resourceItem != null)
-			{
-				// Walk up the visual tree, looking for the resourceItem in each frameworkElement's resource dictionary.
-				while (dependencyObject != null)
-				{
-					FrameworkElement frameworkElement = dependencyObject as FrameworkElement;
-                    if (frameworkElement != null)
-                    {
-                        string resourceKey = GetKeyInResourceDictionary(frameworkElement.Resources, resourceItem);
-                        if (resourceKey != null)
-                        {
-                            return resourceKey;
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
+		    // Walk up the visual tree, looking for the resourceItem in each frameworkElement's resource dictionary.
+		    while (dependencyObject != null)
+		    {
+		        FrameworkElement frameworkElement = dependencyObject as FrameworkElement;
+		        if (frameworkElement != null)
+		        {
+		            string resourceKey = GetKeyInResourceDictionary(frameworkElement.Resources, resourceItem);
+		            if (resourceKey != null)
+		            {
+		                return resourceKey;
+		            }
+		        }
+		        else
+		        {
+		            break;
+		        }
 
-					dependencyObject = VisualTreeHelper.GetParent(dependencyObject);
-				}
+		        dependencyObject = VisualTreeHelper.GetParent(dependencyObject);
+		    }
 
-				// check the application resources
-				if (Application.Current != null)
-				{
-					string resourceKey = GetKeyInResourceDictionary(Application.Current.Resources, resourceItem);
-					if (resourceKey != null)
-						return resourceKey;
-				}
-			}
-			return string.Empty;
+		    // check the application resources
+		    if (Application.Current != null)
+		    {
+		        string resourceKey = GetKeyInResourceDictionary(Application.Current.Resources, resourceItem);
+		        if (resourceKey != null)
+                {
+                    return resourceKey;
+                }
+            }
+
+		    return string.Empty;
 		}
 
 		public static string GetKeyInResourceDictionary(ResourceDictionary dictionary, object resourceItem)

--- a/Snoop/Properties/AssemblyInfo.cs
+++ b/Snoop/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.10.0.0")]
-[assembly: AssemblyFileVersion("2.10.0.0")]
+[assembly: AssemblyVersion("2.11.0.0")]
+[assembly: AssemblyFileVersion("2.11.0.0")]

--- a/Snoop/PropertyInformation.cs
+++ b/Snoop/PropertyInformation.cs
@@ -128,6 +128,8 @@ namespace Snoop
 			BindingOperations.ClearAllBindings(this);
 		}
 
+	    public bool UsesCustomValueBinding { get; }
+
         public object Target { get; }
 
 	    public object Value

--- a/Snoop/PropertyInformation.cs
+++ b/Snoop/PropertyInformation.cs
@@ -98,8 +98,6 @@ namespace Snoop
 	            // in other words, this empty catch block could be hiding some potential future errors.
 	        }
 
-	        this.UsesCustomValueBinding = true;
-
 	        this.Update();
 
 	        this.isRunning = true;
@@ -127,8 +125,6 @@ namespace Snoop
 			this.isRunning = false;
 			BindingOperations.ClearAllBindings(this);
 		}
-
-	    public bool UsesCustomValueBinding { get; }
 
         public object Target { get; }
 

--- a/Snoop/PropertyInformation.cs
+++ b/Snoop/PropertyInformation.cs
@@ -274,26 +274,27 @@ namespace Snoop
 					stringValue = "Transparent";
 				}
 
-				DependencyObject dependencyObject = this.Target as DependencyObject;
-				if (dependencyObject != null && this.DependencyProperty != null)
+			    if (this.Target is DependencyObject dependencyObject)
 				{
 					// Cache the resource key for this item if not cached already. This could be done for more types, but would need to optimize perf.
 					string resourceKey = null;
-					if (this.property != null &&
-						(this.property.PropertyType == typeof(Style) || this.property.PropertyType == typeof(Brush)))
+					if (this.property != null 
+					    && (this.property.PropertyType == typeof(Style) || this.property.PropertyType == typeof(Brush)))
 					{
-						object resourceItem = dependencyObject.GetValue(this.DependencyProperty);
+						var resourceItem = value;
 						resourceKey = ResourceKeyCache.GetKey(resourceItem);
+
 						if (string.IsNullOrEmpty(resourceKey))
 						{
-							resourceKey = ResourceDictionaryKeyHelpers.GetKeyOfResourceItem(dependencyObject, this.DependencyProperty);
+							resourceKey = ResourceDictionaryKeyHelpers.GetKeyOfResourceItem(dependencyObject, resourceItem);
 							ResourceKeyCache.Cache(resourceItem, resourceKey);
 						}
+
 						Debug.Assert(resourceKey != null);
 					}
 
 					// Display both the value and the resource key, if there's a key for this property.
-					if (!string.IsNullOrEmpty(resourceKey))
+					if (string.IsNullOrEmpty(resourceKey) == false)
 					{
 						return string.Format("{0} {1}", resourceKey, stringValue);
 					}

--- a/Snoop/PropertyInformation.cs
+++ b/Snoop/PropertyInformation.cs
@@ -34,7 +34,7 @@ namespace Snoop
 		/// <param name="propertyDisplayName">the display name for the property that goes in the name column</param>
 		public PropertyInformation(object target, PropertyDescriptor property, string propertyName, string propertyDisplayName)
 		{
-			this.target = target;
+			this.Target = target;
 			this.property = property;
 			this.displayName = propertyDisplayName;
 
@@ -83,7 +83,7 @@ namespace Snoop
 	    /// <param name="propertyDisplayName">the display name for the property that goes in the name column</param>
 	    public PropertyInformation(object target, PropertyDescriptor property, BindingBase binding, string propertyDisplayName)
 	    {
-	        this.target = target;
+	        this.Target = target;
 	        this.property = property;
 	        this.displayName = propertyDisplayName;
 
@@ -98,12 +98,14 @@ namespace Snoop
 	            // in other words, this empty catch block could be hiding some potential future errors.
 	        }
 
+	        this.UsesCustomValueBinding = true;
+
 	        this.Update();
 
 	        this.isRunning = true;
-	    }
+	    }	    
 
-		/// <summary>
+	    /// <summary>
 		/// Constructor used when constructing PropertyInformation objects for an item in a collection.
 		/// In this case, we set the PropertyDescriptor for this object (in the property Property) to be null.
 		/// This kind of makes since because an item in a collection really isn't a property on a class.
@@ -126,29 +128,28 @@ namespace Snoop
 			BindingOperations.ClearAllBindings(this);
 		}
 
-		public object Target
-		{
-			get { return this.target; }
-		}
-		private object target;
+        public object Target { get; }
 
-		public object Value
+	    public object Value
 		{
 			get { return this.GetValue(PropertyInformation.ValueProperty); }
 			set { this.SetValue(PropertyInformation.ValueProperty, value); }
 		}
+
 		public static readonly DependencyProperty ValueProperty =
 			DependencyProperty.Register
 			(
-				"Value",
+				nameof(Value),
 				typeof(object),
 				typeof(PropertyInformation),
 				new PropertyMetadata(new PropertyChangedCallback(PropertyInformation.HandleValueChanged))
 			);
+
 		private static void HandleValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
 			((PropertyInformation)d).OnValueChanged();
 		}
+
 		protected virtual void OnValueChanged()
 		{
 			this.Update();
@@ -157,9 +158,12 @@ namespace Snoop
 			{
 				if (this.breakOnChange)
 				{
-					if (!Debugger.IsAttached)
-						Debugger.Launch();
-					Debugger.Break();
+					if (Debugger.IsAttached == false)
+                    {
+                        Debugger.Launch();
+                    }
+
+                    Debugger.Break();
 				}
 
 				this.HasChangedRecently = true;
@@ -177,6 +181,7 @@ namespace Snoop
 				}
 			}
 		}
+
 		private void HandleChangeExpiry(object sender, EventArgs e)
 		{
 			this.changeTimer.Stop();
@@ -184,6 +189,7 @@ namespace Snoop
 
 			this.HasChangedRecently = false;
 		}
+
 		private DispatcherTimer changeTimer;
 
 		public string StringValue
@@ -207,7 +213,7 @@ namespace Snoop
 				Type targetType = this.property.PropertyType;
 				if (targetType.IsAssignableFrom(typeof(string)))
 				{
-					this.property.SetValue(this.target, value);
+					this.property.SetValue(this.Target, value);
 				}
 				else
 				{
@@ -216,7 +222,7 @@ namespace Snoop
 					{
 						try
 						{
-							this.property.SetValue(this.target, converter.ConvertFrom(value));
+							this.property.SetValue(this.Target, converter.ConvertFrom(value));
 						}
 						catch (Exception)
 						{
@@ -504,7 +510,7 @@ namespace Snoop
 			get
 			{
 				DependencyProperty dp = this.DependencyProperty;
-				DependencyObject d = this.target as DependencyObject;
+				DependencyObject d = this.Target as DependencyObject;
 				if (dp != null && d != null)
 					return BindingOperations.GetBindingBase(d, dp);
 				return null;
@@ -516,7 +522,7 @@ namespace Snoop
 			get
 			{
 				DependencyProperty dp = this.DependencyProperty;
-				DependencyObject d = this.target as DependencyObject;
+				DependencyObject d = this.Target as DependencyObject;
 				if (dp != null && d != null)
 					return BindingOperations.GetBindingExpressionBase(d, dp);
 				return null;
@@ -571,9 +577,9 @@ namespace Snoop
 		public void Clear()
 		{
 			DependencyProperty dp = this.DependencyProperty;
-			DependencyObject d = this.target as DependencyObject;
+			DependencyObject d = this.Target as DependencyObject;
 			if (dp != null && d != null)
-				((DependencyObject)this.target).ClearValue(dp);
+				((DependencyObject)this.Target).ClearValue(dp);
 		}
 
 		/// <summary>
@@ -608,7 +614,7 @@ namespace Snoop
 			this.isDatabound = false;
 
 			DependencyProperty dp = this.DependencyProperty;
-			DependencyObject d = target as DependencyObject;
+			DependencyObject d = this.Target as DependencyObject;
 
 			if (SnoopModes.MultipleDispatcherMode && d != null && d.Dispatcher != this.Dispatcher)
 				return;


### PR DESCRIPTION
This PR fixes #111 by always using this.Value in PropertyInformation for the DescriptiveValue.
This can be safely done as this.Value is bound to the value of the DependencyObject in regular cases and is bound to the value of the Setter in case of the Triggers tab.